### PR TITLE
fix: decimals rounding

### DIFF
--- a/src/modules/referral/services/queries.ts
+++ b/src/modules/referral/services/queries.ts
@@ -4,10 +4,10 @@ export const getReferralsQuery = () => {
       *,
       case
         when d."depositorAddr" = $1 and d."referralAddress" = $1
-          then cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * power(10, 18) * d.multiplier as decimal)
+          then trunc(cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * power(10, 18) * d.multiplier as decimal))
         when d."depositorAddr" = $1
-        then cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * 0.25 * power(10, 18) * d.multiplier as decimal)
-        else cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * 0.75 * power(10, 18) * d.multiplier as decimal)
+        then trunc(cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * 0.25 * power(10, 18) * d.multiplier as decimal))
+        else trunc(cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * 0.75 * power(10, 18) * d.multiplier as decimal))
       end as "acxRewards"
     from (
       select d."depositTxHash",
@@ -50,10 +50,10 @@ export const getTotalReferralRewardsQuery = () => {
       sum(
         case
           when d."depositorAddr" = $1 and d."referralAddress" = $1
-            then cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * power(10, 18) * d.multiplier as decimal)
+            then trunc(cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * power(10, 18) * d.multiplier as decimal))
           when d."depositorAddr" = $1
-          then cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * 0.25 * power(10, 18) * d.multiplier as decimal)
-          else cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * 0.75 * power(10, 18) * d.multiplier as decimal)
+          then trunc(cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * 0.25 * power(10, 18) * d.multiplier as decimal))
+          else trunc(cast(d."realizedLpFeeUsd" * d."referralRate" / $2 * 0.75 * power(10, 18) * d.multiplier as decimal))
         end
       ) as "acxRewards"
     from (

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -55,7 +55,7 @@ export class ReferralService {
       transfers,
       volume,
       referralRate,
-      rewardsAmount: new BigNumber(rewardsAmount).decimalPlaces(0, 1),
+      rewardsAmount,
       tier,
       activeRefereesCount,
     };
@@ -71,7 +71,7 @@ export class ReferralService {
     ]);
 
     return {
-      referrals: result.map((item) => ({ ...item, acxRewards: new BigNumber(item.acxRewards).decimalPlaces(0, 1) })),
+      referrals: result.map((item) => ({ ...item, acxRewards: item.acxRewards })),
       pagination: {
         limit,
         offset,


### PR DESCRIPTION
This PR fixes the root cause of the numbers rounding bug. Now the amount of ACX rewards is always truncated 