### PR TITLE
fix: temporary disable env var

### DIFF
--- a/src/modules/scraper/service.ts
+++ b/src/modules/scraper/service.ts
@@ -29,9 +29,9 @@ export class ScraperService {
   public async run() {
     while (true) {
       try {
-        if (this.appConfig.values.enableSpokePoolsEventsProcessing) {
+        // if (this.appConfig.values.enableSpokePoolsEventsProcessing) {
           await this.publishBlocks();
-        }
+        // }
       } catch (error) {
         this.logger.error(error);
       }


### PR DESCRIPTION
I need to undo this change because it was deployed to production due to a Zion issue. 
Actually I discovered that the code pushed to the `stage` branch was incorrectly deployed to production too