### PR TITLE
fix: try to reduce processed block upper limit

### DIFF
--- a/src/modules/scraper/service.ts
+++ b/src/modules/scraper/service.ts
@@ -90,7 +90,7 @@ export class ScraperService {
         from = configStartBlockNumber;
       }
 
-      const to = Math.min(latestBlocks[chainId] - 1, from + this.getMinBlockRange(parseInt(chainId)));
+      const to = Math.min(latestBlocks[chainId] - 2, from + this.getMinBlockRange(parseInt(chainId)));
       if (from < to) {
         blockRanges[chainId] = { from, to };
 


### PR DESCRIPTION
A very small number of FillRelay events (1-4 / day) are not fetched using the getLogs call. This change is meant only for testing