### PR TITLE
fix: include jwt strategy

### DIFF
--- a/src/modules/user/module.ts
+++ b/src/modules/user/module.ts
@@ -1,11 +1,12 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { JwtStrategy } from "../auth/entry-points/http/jwt.strategy";
 import { UserController } from "./entry-points/http/user.controller";
 import { User } from "./model/user.entity";
 import { UserService } from "./services/user.service";
 
 @Module({
-  providers: [UserService],
+  providers: [JwtStrategy, UserService],
   controllers: [UserController],
   imports: [TypeOrmModule.forFeature([User])],
   exports: [UserService],


### PR DESCRIPTION
This PR aims to include the `JwtStrategy` as a provider in the `Users` module. This was the change that allowed me to run the `/users/me` endpoint without an internal server error.

Motivated by:

```
scraper-api-backend | [Nest] 109  - 09/21/2022, 5:44:47 PM   ERROR [ExceptionsHandler] Unknown authentication strategy "jwt"
scraper-api-backend | Error: Unknown authentication strategy "jwt"
scraper-api-backend |     at attempt (/usr/src/app/node_modules/passport/lib/middleware/authenticate.js:193:39)
scraper-api-backend |     at authenticate (/usr/src/app/node_modules/passport/lib/middleware/authenticate.js:370:7)
scraper-api-backend |     at /usr/src/app/node_modules/@nestjs/passport/dist/auth.guard.js:96:3
scraper-api-backend |     at new Promise (<anonymous>)
scraper-api-backend |     at /usr/src/app/node_modules/@nestjs/passport/dist/auth.guard.js:88:83
scraper-api-backend |     at JwtAuthGuard.<anonymous> (/usr/src/app/node_modules/@nestjs/passport/dist/auth.guard.js:49:36)
scraper-api-backend |     at Generator.next (<anonymous>)
scraper-api-backend |     at fulfilled (/usr/src/app/node_modules/@nestjs/passport/dist/auth.guard.js:17:58)
scraper-api-backend |     at runMicrotasks (<anonymous>)
scraper-api-backend |     at processTicksAndRejections (node:internal/process/task_queues:96:5)
```