### PR TITLE
feat: add discord server name and avatar

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -5,7 +5,7 @@
 ### Instructions
 
 1. Initiate the login process by accessing the following URL from the frontend application: 
-`https://discord.com/api/oauth2/authorize?client_id=<CLIENT_ID>&redirect_uri=<REDIRECT_URI>&response_type=code&scope=guilds.members.read%20identify`
+`https://discord.com/api/oauth2/authorize?client_id=<CLIENT_ID>&redirect_uri=<REDIRECT_URI>&response_type=code&scope=guilds.members.read identify`
 
     The `client_id` and `redirect_uri` parameters are recommended to be provided by env variables.
 

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -5,9 +5,11 @@
 ### Instructions
 
 1. Initiate the login process by accessing the following URL from the frontend application: 
-`https://discord.com/api/oauth2/authorize?client_id=<CLIENT_ID>&redirect_uri=<REDIRECT_URI>&response_type=code&scope=identify`
+`https://discord.com/api/oauth2/authorize?client_id=<CLIENT_ID>&redirect_uri=<REDIRECT_URI>&response_type=code&scope=guilds.members.read%20identify`
 
     The `client_id` and `redirect_uri` parameters are recommended to be provided by env variables.
+
+    ⚠️ The URL's query parameters must be encoded with `encodeURIComponent()`
 
 2. User is prompted to allow accessing the Discord account 
 

--- a/migrations/1663529363075-User.ts
+++ b/migrations/1663529363075-User.ts
@@ -8,7 +8,7 @@ export class User1663529363075 implements MigrationInterface {
       "id" SERIAL NOT NULL, 
       "shortId" character varying NOT NULL, 
       "uuid" character varying NOT NULL, 
-      "discordId" character varying NOT NULL, 
+      "discordId" character varying, 
       "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
       "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), 
       CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id")

--- a/migrations/1663940982693-User.ts
+++ b/migrations/1663940982693-User.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class User1663940982693 implements MigrationInterface {
+  name = "User1663940982693";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD "discordName" character varying`);
+    await queryRunner.query(`ALTER TABLE "user" ADD "discordAvatar" character varying`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "discordAvatar"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "discordName"`);
+  }
+}

--- a/src/modules/auth/adapters/discord/api.ts
+++ b/src/modules/auth/adapters/discord/api.ts
@@ -1,0 +1,23 @@
+import { HttpService } from "@nestjs/axios";
+import { Injectable } from "@nestjs/common";
+import { DiscordMeUser, DiscordGuildUser } from "./model";
+
+@Injectable()
+export class DiscordApiService {
+  constructor(private http: HttpService) {}
+
+  public async getUserMe(accessToken: string): Promise<DiscordMeUser> {
+    const response = await this.http.axiosRef.get("https://discordapp.com/api/users/@me", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    return response.data;
+  }
+
+  public async getGuildUser(accessToken: string, guildId: string): Promise<DiscordGuildUser> {
+    const response = await this.http.axiosRef.get(`https://discordapp.com/api/users/@me/guilds/${guildId}/member`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    return response.data;
+  }
+}

--- a/src/modules/auth/adapters/discord/index.ts
+++ b/src/modules/auth/adapters/discord/index.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/src/modules/auth/adapters/discord/model.ts
+++ b/src/modules/auth/adapters/discord/model.ts
@@ -1,0 +1,37 @@
+export type DiscordMeUser = {
+  id: string;
+  username: string;
+  avatar: string;
+  avatar_decoration: string;
+  discriminator: string;
+  public_flags: number;
+  flags: number;
+  banner: string;
+  banner_color: string;
+  accent_color: string;
+  locale: string;
+  mfa_enabled: boolean;
+  premium_type: number;
+};
+
+export type DiscordGuildUser = {
+  avatar: string;
+  communication_disabled_until: string;
+  flags: number;
+  is_pending: boolean;
+  joined_at: string;
+  nick: string;
+  pending: boolean;
+  premium_since: string;
+  roles: [string];
+  user: {
+    id: string;
+    username: string;
+    avatar: string;
+    avatar_decoration: string;
+    discriminator: string;
+    public_flags: number;
+  };
+  mute: boolean;
+  deaf: boolean;
+};

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -9,9 +9,10 @@ import { AuthService } from "./services/auth.service";
 import { configValues } from "../configuration";
 import { AppConfigModule } from "../configuration/configuration.module";
 import { JwtStrategy } from "./entry-points/http/jwt.strategy";
+import { DiscordApiService } from "./adapters/discord";
 
 @Module({
-  providers: [JwtStrategy, DiscordStrategy, AuthService],
+  providers: [JwtStrategy, DiscordStrategy, AuthService, DiscordApiService],
   controllers: [AuthController],
   imports: [
     PassportModule.register({}),

--- a/src/modules/auth/entry-points/http/auth.controller.ts
+++ b/src/modules/auth/entry-points/http/auth.controller.ts
@@ -10,7 +10,11 @@ export class AuthController {
   @Get("discord")
   @UseGuards(DiscordAuthGuard)
   async getUserFromDiscordLogin(@Req() req: any): Promise<any> {
-    const user = await this.userService.createUserFromDiscordId({ discordId: req.user.id });
+    const user = await this.userService.createOrUpdateUserFromDiscord({
+      discordId: req.user.id,
+      discordAvatar: req.user.avatar,
+      discordName: req.user.name,
+    });
     const jwt = this.authService.generateJwtForUser(user);
 
     return { user, jwt };

--- a/src/modules/auth/entry-points/http/discord.strategy.ts
+++ b/src/modules/auth/entry-points/http/discord.strategy.ts
@@ -4,29 +4,49 @@ import { Strategy } from "passport-oauth2";
 import { HttpService } from "@nestjs/axios";
 import { stringify } from "querystring";
 import { AppConfig } from "../../../configuration/configuration.service";
+import { DiscordApiService } from "../../adapters/discord";
+
+const ACROSS_DISCORD_GUILD_ID = "887426921892315137";
 
 @Injectable()
 export class DiscordStrategy extends PassportStrategy(Strategy, "discord") {
-  constructor(private http: HttpService, private config: AppConfig) {
+  constructor(private http: HttpService, private config: AppConfig, private discordApi: DiscordApiService) {
     super({
       authorizationURL: `https://discordapp.com/api/oauth2/authorize?${stringify({
         client_id: config.values.discord.clientId,
         redirect_uri: config.values.discord.redirectUri,
         response_type: "code",
-        scope: "identify",
       })}`,
       tokenURL: "https://discordapp.com/api/oauth2/token",
       clientID: config.values.discord.clientId,
       clientSecret: config.values.discord.clientSecret,
       callbackURL: config.values.discord.redirectUri,
-      scope: "identify",
     });
   }
 
   async validate(accessToken: string): Promise<any> {
-    const response = await this.http.axiosRef.get("https://discordapp.com/api/users/@me", {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    return response.data;
+    let result = {};
+    const user = await this.discordApi.getUserMe(accessToken);
+
+    result = {
+      id: user.id,
+      name: user.username || undefined,
+      avatar: user.avatar ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.jpeg` : undefined,
+    };
+
+    const guildUser = await this.discordApi.getGuildUser(accessToken, ACROSS_DISCORD_GUILD_ID);
+
+    if (guildUser?.nick) {
+      result = { ...result, name: guildUser.nick };
+    }
+
+    if (guildUser?.avatar) {
+      result = {
+        ...result,
+        avatar: `https://cdn.discordapp.com/guilds/${ACROSS_DISCORD_GUILD_ID}/users/${user.id}/avatars/${guildUser.avatar}.jpeg`,
+      };
+    }
+
+    return result;
   }
 }

--- a/src/modules/user/model/user.entity.ts
+++ b/src/modules/user/model/user.entity.ts
@@ -11,8 +11,14 @@ export class User {
   @Column()
   uuid: string;
 
-  @Column()
-  discordId: string;
+  @Column({ nullable: true })
+  discordId?: string;
+
+  @Column({ nullable: true })
+  discordName?: string;
+
+  @Column({ nullable: true })
+  discordAvatar?: string;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -10,15 +10,26 @@ import { UserNotFoundException } from "./exceptions";
 export class UserService {
   constructor(@InjectRepository(User) private userRepository: Repository<User>) {}
 
-  public async createUserFromDiscordId({ discordId }: { discordId: string }) {
+  public async createOrUpdateUserFromDiscord({
+    discordId,
+    discordAvatar,
+    discordName,
+  }: {
+    discordId: string;
+    discordName: string;
+    discordAvatar: string;
+  }) {
     let user = await this.userRepository.findOne({ where: { discordId } });
 
     if (!user) {
       const shortId = await this.createShortId();
       const uuid = this.createUUID();
       user = this.userRepository.create({ discordId, shortId, uuid });
-      user = await this.userRepository.save(user);
     }
+
+    user.discordName = discordName;
+    user.discordAvatar = discordAvatar;
+    user = await this.userRepository.save(user);
 
     return user;
   }


### PR DESCRIPTION
This PR updates the user entity and logic in order to store the Discord username and avatar. If the user is part of the Across Discord server, the global name and avatar are overwritten with the ones used on the server