### PR TITLE
feat: add wallet and community rewards

### DIFF
--- a/migrations/1664210580112-CommunityRewards.ts
+++ b/migrations/1664210580112-CommunityRewards.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CommunityRewards1664210580112 implements MigrationInterface {
+  name = "CommunityRewards1664210580112";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "community_rewards" (
+            "id" SERIAL NOT NULL, 
+        "discordId" character varying NOT NULL, 
+        "amount" numeric NOT NULL, 
+        "processed" boolean NOT NULL DEFAULT true, 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "UK_community_rewards_discordId" UNIQUE ("discordId"), 
+        CONSTRAINT "PK_8a9bde213ca3fea572c33d8fd9e" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(`CREATE INDEX "IX_community_rewards_discordId" ON "community_rewards" ("discordId") `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IX_community_rewards_discordId"`);
+    await queryRunner.query(`DROP TABLE "community_rewards"`);
+  }
+}

--- a/migrations/1664210580112-WalletRewards.ts
+++ b/migrations/1664210580112-WalletRewards.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class WalletRewards1664210580112 implements MigrationInterface {
+  name = "WalletRewards1664210580112";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "wallet_rewards" (
+        "id" SERIAL NOT NULL, 
+        "walletAddress" character varying NOT NULL, 
+        "welcomeTravellerRewards" numeric NOT NULL, 
+        "earlyUserRewards" numeric NOT NULL, 
+        "liquidityProviderRewards" numeric NOT NULL, 
+        "processed" boolean NOT NULL DEFAULT true, 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "UK_wallet_rewards_walletAddress" UNIQUE ("walletAddress"), 
+        CONSTRAINT "PK_35794b255a8e427f320dd3baded" PRIMARY KEY ("id"))`);
+    await queryRunner.query(`CREATE INDEX "IX_wallet_rewards_walletAddress" ON "wallet_rewards" ("walletAddress")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IX_wallet_rewards_walletAddress"`);
+    await queryRunner.query(`DROP TABLE "wallet_rewards"`);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/express": "^4.17.13",
     "@types/jest": "^27.4.1",
     "@types/luxon": "^2.3.2",
+    "@types/multer": "^1.4.7",
     "@types/nanoid": "^3.0.0",
     "@types/node": "^17.0.23",
     "@types/passport-jwt": "^3.0.6",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { Web3Module } from "./modules/web3/module";
 import { DepositModule } from "./modules/deposit/module";
 import { AuthModule } from "./modules/auth/auth.module";
 import { UserModule } from "./modules/user/module";
+import { AirdropModule } from "./modules/airdrop/module";
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { UserModule } from "./modules/user/module";
     DepositModule,
     AuthModule,
     UserModule,
+    AirdropModule,
   ],
 })
 export class AppModule {

--- a/src/modules/airdrop/adapter/db/community-rewards-fixture.ts
+++ b/src/modules/airdrop/adapter/db/community-rewards-fixture.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { CommunityRewards } from "../../model/community-rewards.entity";
+
+@Injectable()
+export class CommunityRewardsFixture {
+  public constructor(
+    @InjectRepository(CommunityRewards) private communityRewardsRepository: Repository<CommunityRewards>,
+  ) {}
+
+  public insertCommunityRewards(args: Partial<CommunityRewards> = {}) {
+    const communityRewards = this.communityRewardsRepository.create(this.mockCommunityRewardsEntity(args));
+    return this.communityRewardsRepository.save(communityRewards);
+  }
+
+  public insertManyCommunityRewards(args: Partial<CommunityRewards>[] = [{}]) {
+    const rewards = this.communityRewardsRepository.create(args.map((arg) => this.mockCommunityRewardsEntity(arg)));
+    return this.communityRewardsRepository.save(rewards);
+  }
+
+  public mockCommunityRewardsEntity(overrides: Partial<CommunityRewards> = {}): Partial<CommunityRewards> {
+    return {
+      discordId: "discordId",
+      amount: "100",
+      processed: true,
+      ...overrides,
+    };
+  }
+
+  public deleteAllCommunityRewards() {
+    return this.communityRewardsRepository.query(`truncate table "community_rewards" restart identity cascade`);
+  }
+}

--- a/src/modules/airdrop/adapter/db/wallet-rewards-fixture.ts
+++ b/src/modules/airdrop/adapter/db/wallet-rewards-fixture.ts
@@ -1,0 +1,33 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { WalletRewards } from "../../model/wallet-rewards.entity";
+
+@Injectable()
+export class WalletRewardsFixture {
+  public constructor(@InjectRepository(WalletRewards) private depositRepository: Repository<WalletRewards>) {}
+
+  public insertWalletRewards(args: Partial<WalletRewards> = {}) {
+    const deposit = this.depositRepository.create(this.mockWalletRewardsEntity(args));
+    return this.depositRepository.save(deposit);
+  }
+
+  public insertManyWalletRewards(args: Partial<WalletRewards>[] = [{}]) {
+    const createdDeposits = this.depositRepository.create(args.map((arg) => this.mockWalletRewardsEntity(arg)));
+    return this.depositRepository.save(createdDeposits);
+  }
+
+  public mockWalletRewardsEntity(overrides: Partial<WalletRewards> = {}): Partial<WalletRewards> {
+    return {
+      earlyUserRewards: "0",
+      liquidityProviderRewards: "0",
+      welcomeTravellerRewards: "0",
+      walletAddress: "0x0000000000000000000000000000000000000000",
+      ...overrides,
+    };
+  }
+
+  public deleteAllWalletRewards() {
+    return this.depositRepository.query(`truncate table "wallet_rewards" restart identity cascade`);
+  }
+}

--- a/src/modules/airdrop/entry-points/http/controller.ts
+++ b/src/modules/airdrop/entry-points/http/controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, Post, Query, UploadedFiles, UseGuards, UseInterceptors } from "@nestjs/common";
+import { FileFieldsInterceptor } from "@nestjs/platform-express";
+import { ApiResponse, ApiTags } from "@nestjs/swagger";
+import { JwtAuthGuard } from "../../../auth/entry-points/http/jwt.guard";
+import { Role, Roles, RolesGuard } from "../../../auth/entry-points/http/roles";
+import { AirdropService } from "../../services/airdrop-service";
+import { GetAirdropRewardsQuery, GetAirdropRewardsResponse } from "./dto";
+
+@Controller("airdrop")
+export class AirdropController {
+  constructor(private airdropService: AirdropService) {}
+
+  @Get("rewards")
+  @ApiResponse({ type: GetAirdropRewardsResponse })
+  @ApiTags("airdrop")
+  getAirdropRewards(@Query() query: GetAirdropRewardsQuery) {
+    return this.airdropService.getRewards(query.address);
+  }
+
+  @Post("upload/rewards")
+  @Roles(Role.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @UseInterceptors(
+    FileFieldsInterceptor(
+      [
+        { name: "walletRewards", maxCount: 1 },
+        { name: "communityRewards", maxCount: 1 },
+      ],
+      {
+        limits: { fileSize: 50 * 1024 * 1024 },
+        dest: "/uploads",
+      },
+    ),
+  )
+  async feedWalletRewards(
+    @UploadedFiles() files: { walletRewards?: Express.Multer.File[]; communityRewards?: Express.Multer.File[] },
+  ) {
+    return this.airdropService.processUploadedRewardsFiles({
+      communityRewardsFile: files.communityRewards[0],
+      walletRewardsFile: files.walletRewards[0],
+    });
+  }
+}

--- a/src/modules/airdrop/entry-points/http/dto.ts
+++ b/src/modules/airdrop/entry-points/http/dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, Length } from "class-validator";
+
+export class GetAirdropRewardsQuery {
+  @IsString()
+  @Length(42, 42, { message: "Invalid Ethereum address length" })
+  @ApiProperty()
+  address: string;
+}
+
+export class GetAirdropRewardsCategoryResponse {
+  @ApiProperty()
+  eligible: boolean;
+
+  @ApiProperty({ example: "1000", description: "Rewards amount in wei" })
+  amount: string;
+}
+
+export class GetAirdropRewardsCategoryWithCompletedResponse {
+  @ApiProperty()
+  eligible: boolean;
+
+  @ApiProperty({ example: "1000", description: "Rewards amount in wei" })
+  amount: string;
+
+  @ApiProperty({ example: false })
+  completed: boolean;
+}
+
+export class GetAirdropRewardsResponse {
+  @ApiProperty()
+  welcomeTravellerRewards: GetAirdropRewardsCategoryWithCompletedResponse;
+
+  @ApiProperty()
+  earlyUserRewards: GetAirdropRewardsCategoryResponse;
+
+  @ApiProperty()
+  liquidityProviderRewards: GetAirdropRewardsCategoryResponse;
+
+  @ApiProperty()
+  communityRewards: GetAirdropRewardsCategoryResponse;
+}

--- a/src/modules/airdrop/model/community-rewards.entity.ts
+++ b/src/modules/airdrop/model/community-rewards.entity.ts
@@ -1,0 +1,24 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, Unique, UpdateDateColumn } from "typeorm";
+
+@Entity()
+@Index("IX_community_rewards_discordId", ["discordId"])
+@Unique("UK_community_rewards_discordId", ["discordId"])
+export class CommunityRewards {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  discordId: string;
+
+  @Column({ type: "decimal" })
+  amount: string;
+
+  @Column({ default: true })
+  processed: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/airdrop/model/wallet-rewards.entity.ts
+++ b/src/modules/airdrop/model/wallet-rewards.entity.ts
@@ -1,0 +1,30 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, Unique, UpdateDateColumn } from "typeorm";
+
+@Entity()
+@Unique("UK_wallet_rewards_walletAddress", ["walletAddress"])
+@Index("IX_wallet_rewards_walletAddress", ["walletAddress"])
+export class WalletRewards {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  walletAddress: string;
+
+  @Column({ type: "decimal" })
+  welcomeTravellerRewards: string;
+
+  @Column({ type: "decimal" })
+  earlyUserRewards: string;
+
+  @Column({ type: "decimal" })
+  liquidityProviderRewards: string;
+
+  @Column({ default: true })
+  processed: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/airdrop/module.ts
+++ b/src/modules/airdrop/module.ts
@@ -1,0 +1,21 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { UserModule } from "../user/module";
+
+import { WalletRewardsFixture } from "./adapter/db/wallet-rewards-fixture";
+import { CommunityRewardsFixture } from "./adapter/db/community-rewards-fixture";
+import { AirdropService } from "./services/airdrop-service";
+import { AirdropController } from "./entry-points/http/controller";
+
+import { CommunityRewards } from "./model/community-rewards.entity";
+import { WalletRewards } from "./model/wallet-rewards.entity";
+import { Deposit } from "../scraper/model/deposit.entity";
+
+@Module({
+  providers: [AirdropService, WalletRewardsFixture, CommunityRewardsFixture],
+  controllers: [AirdropController],
+  imports: [TypeOrmModule.forFeature([CommunityRewards, WalletRewards, Deposit]), UserModule],
+  exports: [],
+})
+export class AirdropModule {}

--- a/src/modules/airdrop/services/airdrop-service.ts
+++ b/src/modules/airdrop/services/airdrop-service.ts
@@ -1,0 +1,196 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ethers } from "ethers";
+import { readFile } from "fs/promises";
+import BigNumber from "bignumber.js";
+import { IsNull, Not, Repository } from "typeorm";
+
+import { UserService } from "../../user/services/user.service";
+import { UserWalletService } from "../../user/services/user-wallet.service";
+
+import { Deposit } from "../../scraper/model/deposit.entity";
+import { CommunityRewards } from "../model/community-rewards.entity";
+import { WalletRewards } from "../model/wallet-rewards.entity";
+
+import { ProcessCommunityRewardsFileException, ProcessWalletRewardsFileException } from "./exceptions";
+
+@Injectable()
+export class AirdropService {
+  private logger = new Logger(AirdropService.name);
+
+  constructor(
+    @InjectRepository(CommunityRewards) private communityRewardsRepository: Repository<CommunityRewards>,
+    @InjectRepository(WalletRewards) private walletRewardsRepository: Repository<WalletRewards>,
+    @InjectRepository(Deposit) private depositRepository: Repository<Deposit>,
+    private userWalletService: UserWalletService,
+    private userService: UserService,
+  ) {}
+
+  public async getRewards(walletAddress: string) {
+    const checksumAddress = ethers.utils.getAddress(walletAddress);
+    const walletRewards = await this.getWalletRewards(checksumAddress);
+    const communityRewards: string = await this.getCommunityRewards(checksumAddress);
+    const welcomeTravellerEligible = !!walletRewards && new BigNumber(walletRewards.welcomeTravellerRewards).gt(0);
+    let welcomeTravellerCompleted = false;
+
+    if (welcomeTravellerEligible) {
+      const depositCount = await this.depositRepository.count({
+        where: { depositorAddr: checksumAddress, status: "filled" },
+      });
+
+      if (depositCount > 0) {
+        welcomeTravellerCompleted = true;
+      }
+    }
+
+    return {
+      welcomeTravellerRewards: {
+        eligible: welcomeTravellerEligible,
+        completed: welcomeTravellerCompleted,
+        amount: walletRewards?.welcomeTravellerRewards || "0",
+      },
+      earlyUserRewards: {
+        eligible: !!walletRewards && new BigNumber(walletRewards.earlyUserRewards).gt(0),
+        amount: walletRewards?.earlyUserRewards || "0",
+      },
+      liquidityProviderRewards: {
+        eligible: !!walletRewards && new BigNumber(walletRewards.liquidityProviderRewards).gt(0),
+        amount: walletRewards?.liquidityProviderRewards || "0",
+      },
+      communityRewards: {
+        eligible: communityRewards ? new BigNumber(communityRewards).gt(0) : false,
+        amount: communityRewards || "0",
+      },
+    };
+  }
+
+  async processUploadedRewardsFiles({
+    walletRewardsFile,
+    communityRewardsFile,
+  }: {
+    walletRewardsFile?: Express.Multer.File;
+    communityRewardsFile?: Express.Multer.File;
+  }) {
+    if (communityRewardsFile) {
+      await this.processCommunityRewardsFile(communityRewardsFile);
+    }
+
+    if (walletRewardsFile) {
+      await this.processWalletRewardsFile(walletRewardsFile);
+    }
+
+    const [communityRewardsCount, walletRewardsCount] = await Promise.all([
+      this.communityRewardsRepository.count(),
+      this.walletRewardsRepository.count(),
+    ]);
+
+    return {
+      communityRewardsCount,
+      walletRewardsCount,
+    };
+  }
+
+  private async processWalletRewardsFile(walletRewardsFile: Express.Multer.File) {
+    try {
+      await this.walletRewardsRepository.update({ id: Not(IsNull()) }, { processed: false });
+      const walletRewardsContent = await readFile(walletRewardsFile.path, { encoding: "utf8" });
+      const walletRewards = JSON.parse(walletRewardsContent);
+
+      for (const walletAddress of Object.keys(walletRewards)) {
+        await this.insertWalletRewards({
+          walletAddress: ethers.utils.getAddress(walletAddress),
+          earlyUserRewards: walletRewards[walletAddress]["bridgoor"] || 0,
+          liquidityProviderRewards: walletRewards[walletAddress]["lp"] || 0,
+          welcomeTravellerRewards: walletRewards[walletAddress]["bridge-traveler"] || 0,
+        });
+      }
+    } catch (error) {
+      this.logger.error(error);
+      await this.walletRewardsRepository.update({ id: Not(IsNull()) }, { processed: true });
+      throw new ProcessWalletRewardsFileException();
+    }
+  }
+
+  private async processCommunityRewardsFile(communityRewardsFile: Express.Multer.File) {
+    try {
+      await this.communityRewardsRepository.update({ id: Not(IsNull()) }, { processed: false });
+
+      const communityRewardsContent = await readFile(communityRewardsFile.path, { encoding: "utf8" });
+      const communityRewards = JSON.parse(communityRewardsContent);
+
+      for (const communityReward of communityRewards) {
+        if (communityReward["ID"] && communityReward["Total Tokens"]) {
+          await this.insertCommunityRewards(communityReward["ID"], communityReward["Total Tokens"]);
+        }
+      }
+      await this.communityRewardsRepository.delete({ processed: false });
+    } catch (error) {
+      this.logger.error(error);
+      await this.communityRewardsRepository.update({ id: Not(IsNull()) }, { processed: true });
+      throw new ProcessCommunityRewardsFileException();
+    }
+  }
+
+  private async insertCommunityRewards(discordId: string, amount: number) {
+    let communityRewards = await this.communityRewardsRepository.findOne({ where: { discordId } });
+
+    if (!communityRewards) {
+      communityRewards = this.communityRewardsRepository.create();
+    }
+
+    const wei = new BigNumber(10).pow(18);
+    communityRewards.amount = new BigNumber(amount).multipliedBy(wei).toString();
+    communityRewards.discordId = discordId;
+    communityRewards.processed = true;
+
+    await this.communityRewardsRepository.save(communityRewards);
+  }
+
+  private async insertWalletRewards({
+    earlyUserRewards,
+    liquidityProviderRewards,
+    walletAddress,
+    welcomeTravellerRewards,
+  }: {
+    walletAddress: string;
+    earlyUserRewards: number;
+    liquidityProviderRewards: number;
+    welcomeTravellerRewards: number;
+  }) {
+    let walletRewards = await this.walletRewardsRepository.findOne({ where: { walletAddress } });
+
+    if (!walletRewards) {
+      walletRewards = this.walletRewardsRepository.create();
+    }
+
+    const wei = new BigNumber(10).pow(18);
+    walletRewards.earlyUserRewards = new BigNumber(earlyUserRewards).multipliedBy(wei).toString();
+    walletRewards.liquidityProviderRewards = new BigNumber(liquidityProviderRewards).multipliedBy(wei).toString();
+    walletRewards.welcomeTravellerRewards = new BigNumber(welcomeTravellerRewards).multipliedBy(wei).toString();
+    walletRewards.walletAddress = walletAddress;
+    walletRewards.processed = true;
+
+    await this.walletRewardsRepository.save(walletRewards);
+  }
+
+  private async getWalletRewards(walletAddress: string) {
+    return this.walletRewardsRepository.findOne({ where: { walletAddress } });
+  }
+
+  private async getCommunityRewards(walletAddress: string): Promise<string | undefined> {
+    const userWallet = await this.userWalletService.getUserWalletByAttributes({ walletAddress });
+
+    if (!userWallet) {
+      return undefined;
+    }
+
+    const user = await this.userService.getUserByAttributes({ id: userWallet.userId });
+    const communityRewards = await this.communityRewardsRepository.findOne({ where: { discordId: user.discordId } });
+
+    if (!communityRewards) {
+      return undefined;
+    }
+
+    return communityRewards.amount;
+  }
+}

--- a/src/modules/airdrop/services/exceptions.ts
+++ b/src/modules/airdrop/services/exceptions.ts
@@ -1,0 +1,25 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+
+export class ProcessCommunityRewardsFileException extends HttpException {
+  constructor() {
+    super(
+      {
+        error: ProcessCommunityRewardsFileException.name,
+        message: "Could not process community rewards JSON file",
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}
+
+export class ProcessWalletRewardsFileException extends HttpException {
+  constructor() {
+    super(
+      {
+        error: ProcessWalletRewardsFileException.name,
+        message: "Could not process wallets rewards JSON file",
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}

--- a/src/modules/auth/entry-points/http/jwt.strategy.ts
+++ b/src/modules/auth/entry-points/http/jwt.strategy.ts
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { id: payload.id };
+    return { id: payload.id, roles: payload.roles };
   }
 }

--- a/src/modules/auth/entry-points/http/roles.ts
+++ b/src/modules/auth/entry-points/http/roles.ts
@@ -1,0 +1,28 @@
+import { SetMetadata } from "@nestjs/common";
+import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+
+export enum Role {
+  User = "user",
+  Admin = "admin",
+}
+
+export const ROLES_KEY = "roles";
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles) {
+      return true;
+    }
+    const req = context.switchToHttp().getRequest();
+    return requiredRoles.some((role) => req.user?.roles?.includes(role));
+  }
+}

--- a/src/modules/database/database.providers.ts
+++ b/src/modules/database/database.providers.ts
@@ -23,7 +23,7 @@ const entities = [
   User,
   WalletRewards,
   CommunityRewards,
-  UserWallet
+  UserWallet,
 ];
 
 @Injectable()

--- a/src/modules/database/database.providers.ts
+++ b/src/modules/database/database.providers.ts
@@ -8,10 +8,23 @@ import { Token } from "../web3/model/token.entity";
 import { Transaction } from "../web3/model/transaction.entity";
 import { HistoricMarketPrice } from "../market-price/model/historic-market-price.entity";
 import { User } from "../user/model/user.entity";
+import { WalletRewards } from "../airdrop/model/wallet-rewards.entity";
+import { CommunityRewards } from "../airdrop/model/community-rewards.entity";
 import { UserWallet } from "../user/model/user-wallet.entity";
 
 // TODO: Add db entities here
-const entities = [ProcessedBlock, Block, Deposit, Token, Transaction, HistoricMarketPrice, User, UserWallet];
+const entities = [
+  ProcessedBlock,
+  Block,
+  Deposit,
+  Token,
+  Transaction,
+  HistoricMarketPrice,
+  User,
+  WalletRewards,
+  CommunityRewards,
+  UserWallet
+];
 
 @Injectable()
 export class TypeOrmDefaultConfigService implements TypeOrmOptionsFactory {

--- a/src/modules/scraper/adapter/db/deposit-fixture.ts
+++ b/src/modules/scraper/adapter/db/deposit-fixture.ts
@@ -3,6 +3,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Deposit, DepositFillTx, TransferStatus } from "../../model/deposit.entity";
+import { getRandomInt } from "../../../../utils";
 
 @Injectable()
 export class DepositFixture {
@@ -25,7 +26,7 @@ export class DepositFixture {
 
 export function mockDepositEntity(overrides: Partial<Deposit>) {
   return {
-    depositId: 1,
+    depositId: getRandomInt(),
     sourceChainId: 1,
     destinationChainId: 1,
     depositDate: new Date(),

--- a/src/modules/scraper/module.ts
+++ b/src/modules/scraper/module.ts
@@ -1,6 +1,6 @@
 import { HttpModule } from "@nestjs/axios";
 import { BullModule } from "@nestjs/bull";
-import { forwardRef, Module } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { AppConfigModule } from "../configuration/configuration.module";

--- a/src/modules/scraper/service.ts
+++ b/src/modules/scraper/service.ts
@@ -10,8 +10,6 @@ import { ScraperQueuesService } from "./service/ScraperQueuesService";
 import { BlocksEventsQueueMessage, ScraperQueue } from "./adapter/messaging";
 import { wait } from "../../utils";
 
-type Task = Record<string, { from: number; to: number }>;
-
 @Injectable()
 export class ScraperService {
   private logger = new Logger(ScraperService.name);

--- a/src/modules/user/adapter/db/user-fixture.ts
+++ b/src/modules/user/adapter/db/user-fixture.ts
@@ -1,0 +1,40 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { customAlphabet } from "nanoid";
+import { Repository } from "typeorm";
+import { v4 as uuidv4 } from "uuid";
+import { User } from "../../model/user.entity";
+
+@Injectable()
+export class UserFixture {
+  public constructor(@InjectRepository(User) private userRepository: Repository<User>) {}
+
+  public insertUser(args: Partial<User> = {}) {
+    const user = this.userRepository.create(this.mockUserEntity(args));
+    return this.userRepository.save(user);
+  }
+
+  public mockUserEntity(overrides: Partial<User> = {}): Partial<User> {
+    return {
+      discordAvatar: "avatar",
+      discordId: "1",
+      discordName: "name",
+      shortId: this.createShortId(),
+      uuid: this.createUUID(),
+      ...overrides,
+    };
+  }
+
+  public deleteAllUsers() {
+    return this.userRepository.query(`truncate table "user" restart identity cascade`);
+  }
+
+  public createShortId() {
+    const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    return customAlphabet(alphabet, 16)();
+  }
+
+  public createUUID() {
+    return uuidv4();
+  }
+}

--- a/src/modules/user/adapter/db/user-wallet-fixture.ts
+++ b/src/modules/user/adapter/db/user-wallet-fixture.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { UserWallet } from "../../model/user-wallet.entity";
+
+@Injectable()
+export class UserWalletFixture {
+  public constructor(@InjectRepository(UserWallet) private userWalletRepository: Repository<UserWallet>) {}
+
+  public insertUserWallet(args: Partial<UserWallet> = {}) {
+    const user = this.userWalletRepository.create(this.mockUserWalletEntity(args));
+    return this.userWalletRepository.save(user);
+  }
+
+  public mockUserWalletEntity(overrides: Partial<UserWallet> = {}): Partial<UserWallet> {
+    return {
+      userId: 1,
+      walletAddress: "0x",
+      ...overrides,
+    };
+  }
+
+  public deleteAllUserWallets() {
+    return this.userWalletRepository.query(`truncate table "user_wallet" restart identity cascade`);
+  }
+}

--- a/src/modules/user/module.ts
+++ b/src/modules/user/module.ts
@@ -5,9 +5,11 @@ import { User } from "./model/user.entity";
 import { UserWallet } from "./model/user-wallet.entity";
 import { UserService } from "./services/user.service";
 import { UserWalletService } from "./services/user-wallet.service";
+import { UserFixture } from "./adapter/db/user-fixture";
+import { UserWalletFixture } from "./adapter/db/user-wallet-fixture";
 
 @Module({
-  providers: [UserService, UserWalletService],
+  providers: [UserService, UserWalletService, UserFixture, UserWalletFixture],
   controllers: [UserController],
   imports: [TypeOrmModule.forFeature([User, UserWallet])],
   exports: [UserService, UserWalletService],

--- a/src/modules/user/services/exceptions.ts
+++ b/src/modules/user/services/exceptions.ts
@@ -24,6 +24,18 @@ export class WalletNotFoundException extends HttpException {
   }
 }
 
+export class UserWalletNotFoundException extends HttpException {
+  constructor() {
+    super(
+      {
+        error: UserWalletNotFoundException.name,
+        message: `User wallet not found`,
+      },
+      HttpStatus.NOT_FOUND,
+    );
+  }
+}
+
 export class InvalidSignatureException extends HttpException {
   constructor() {
     super(

--- a/src/modules/user/services/user-wallet.service.ts
+++ b/src/modules/user/services/user-wallet.service.ts
@@ -4,7 +4,12 @@ import { FindOptionsWhere, Repository } from "typeorm";
 import { utils } from "ethers";
 
 import { UserWallet } from "../model/user-wallet.entity";
-import { InvalidSignatureException, WalletNotFoundException, WalletAlreadyLinkedException, UserWalletNotFoundException } from "./exceptions";
+import {
+  InvalidSignatureException,
+  WalletNotFoundException,
+  WalletAlreadyLinkedException,
+  UserWalletNotFoundException,
+} from "./exceptions";
 import { UserService } from "./user.service";
 
 @Injectable()

--- a/src/modules/user/services/user-wallet.service.ts
+++ b/src/modules/user/services/user-wallet.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Inject } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { FindOptionsWhere, Repository } from "typeorm";
 import { utils } from "ethers";
 
 import { UserWallet } from "../model/user-wallet.entity";
-import { InvalidSignatureException, WalletNotFoundException, WalletAlreadyLinkedException } from "./exceptions";
+import { InvalidSignatureException, WalletNotFoundException, WalletAlreadyLinkedException, UserWalletNotFoundException } from "./exceptions";
 import { UserService } from "./user.service";
 
 @Injectable()
@@ -112,5 +112,19 @@ export class UserWalletService {
 
   public async assertUserExists(userId: number) {
     await this.userService.getUserByAttributes({ id: userId }, true);
+  }
+
+  public async getUserWalletByAttributes(
+    where: FindOptionsWhere<UserWallet>,
+    validate = false,
+    select?: (keyof UserWallet)[],
+  ) {
+    const user = await this.userWalletRepository.findOne({ where, select });
+
+    if (!user && validate) {
+      throw new UserWalletNotFoundException();
+    }
+
+    return user;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,3 +11,9 @@ export const EnhancedCron = (cronExpression: string) => {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   else return () => {};
 };
+
+export const getRandomInt = (min = 0, max = 1000000) => {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};

--- a/test/airdrop.e2e-spec.ts
+++ b/test/airdrop.e2e-spec.ts
@@ -1,0 +1,144 @@
+import request from "supertest";
+import { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { JwtService } from "@nestjs/jwt";
+
+import { ValidationPipe } from "../src/validation.pipe";
+import { AppModule } from "../src/app.module";
+import { GetAirdropRewardsResponse } from "../src/modules/airdrop/entry-points/http/dto";
+import { DepositFixture, mockDepositEntity } from "../src/modules/scraper/adapter/db/deposit-fixture";
+import { Role } from "../src/modules/auth/entry-points/http/roles";
+import { WalletRewardsFixture } from "../src/modules/airdrop/adapter/db/wallet-rewards-fixture";
+import { CommunityRewardsFixture } from "../src/modules/airdrop/adapter/db/community-rewards-fixture";
+import { UserFixture } from "../src/modules/user/adapter/db/user-fixture";
+import { UserWalletFixture } from "../src/modules/user/adapter/db/user-wallet-fixture";
+
+let app: INestApplication;
+
+beforeAll(async () => {
+  const moduleFixture = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  app = moduleFixture.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe());
+  await app.init();
+});
+
+describe("GET /airdrop/rewards", () => {
+  let walletRewardsFixture: WalletRewardsFixture;
+  let communityRewardsFixture: CommunityRewardsFixture;
+  let depositFixture: DepositFixture;
+  let userFixture: UserFixture;
+  let userWalletFixture: UserWalletFixture;
+
+  beforeAll(async () => {
+    walletRewardsFixture = app.get(WalletRewardsFixture);
+    communityRewardsFixture = app.get(CommunityRewardsFixture);
+    depositFixture = app.get(DepositFixture);
+    userFixture = app.get(UserFixture);
+    userWalletFixture = app.get(UserWalletFixture);
+
+    await communityRewardsFixture.insertManyCommunityRewards([{ discordId: "1", amount: "100" }]);
+    await walletRewardsFixture.insertManyWalletRewards([
+      {
+        walletAddress: "0x0000000000000000000000000000000000000001",
+        earlyUserRewards: "1",
+        liquidityProviderRewards: "0",
+        welcomeTravellerRewards: "0",
+      },
+      {
+        walletAddress: "0x0000000000000000000000000000000000000002",
+        earlyUserRewards: "1",
+        liquidityProviderRewards: "1",
+        welcomeTravellerRewards: "1",
+      },
+    ]);
+  });
+
+  it("should not be elligible", async () => {
+    const response = await request(app.getHttpServer())
+      .get("/airdrop/rewards")
+      .query({ address: "0x0000000000000000000000000000000000000003" });
+    const responseBody = response.body as GetAirdropRewardsResponse;
+    expect(response.status).toBe(200);
+    expect(responseBody.communityRewards.eligible).toEqual(false);
+    expect(responseBody.earlyUserRewards.eligible).toEqual(false);
+    expect(responseBody.liquidityProviderRewards.eligible).toEqual(false);
+  });
+
+  it("should be elligible for earlyUserRewards", async () => {
+    const response = await request(app.getHttpServer())
+      .get("/airdrop/rewards")
+      .query({ address: "0x0000000000000000000000000000000000000001" });
+    const responseBody = response.body as GetAirdropRewardsResponse;
+    expect(response.status).toBe(200);
+    expect(responseBody.communityRewards.eligible).toEqual(false);
+    expect(responseBody.earlyUserRewards.eligible).toEqual(true);
+    expect(responseBody.liquidityProviderRewards.eligible).toEqual(false);
+  });
+
+  it("should be elligible for all rewards, but welcome traveller not completed", async () => {
+    const user = await userFixture.insertUser({ discordId: "1" });
+    await userWalletFixture.insertUserWallet({
+      userId: user.id,
+      walletAddress: "0x0000000000000000000000000000000000000002",
+    });
+    const response = await request(app.getHttpServer())
+      .get("/airdrop/rewards")
+      .query({ address: "0x0000000000000000000000000000000000000002" });
+    const responseBody = response.body as GetAirdropRewardsResponse;
+    expect(response.status).toBe(200);
+    expect(responseBody.communityRewards.eligible).toEqual(true);
+    expect(responseBody.earlyUserRewards.eligible).toEqual(true);
+    expect(responseBody.liquidityProviderRewards.eligible).toEqual(true);
+    expect(responseBody.welcomeTravellerRewards.completed).toEqual(false);
+  });
+
+  it("should see traveller rewards as completed", async () => {
+    await depositFixture.insertDeposit(
+      mockDepositEntity({ depositorAddr: "0x0000000000000000000000000000000000000002", status: "filled" }),
+    );
+    const response = await request(app.getHttpServer())
+      .get("/airdrop/rewards")
+      .query({ address: "0x0000000000000000000000000000000000000002" });
+    const responseBody = response.body as GetAirdropRewardsResponse;
+    expect(response.status).toBe(200);
+    expect(responseBody.communityRewards.eligible).toEqual(true);
+    expect(responseBody.earlyUserRewards.eligible).toEqual(true);
+    expect(responseBody.liquidityProviderRewards.eligible).toEqual(true);
+    expect(responseBody.welcomeTravellerRewards.completed).toEqual(true);
+  });
+
+  afterAll(async () => {
+    await walletRewardsFixture.deleteAllWalletRewards();
+    await communityRewardsFixture.deleteAllCommunityRewards();
+    await depositFixture.deleteAllDeposits();
+    await userFixture.deleteAllUsers();
+    await userWalletFixture.deleteAllUserWallets();
+  });
+});
+
+describe("POST /airdrop/upload/rewards", () => {
+  beforeAll(async () => {});
+
+  it("should not be authorized if token is not attached", async () => {
+    const response = await request(app.getHttpServer()).post("/airdrop/upload/rewards");
+    expect(response.statusCode).toStrictEqual(401);
+  });
+
+  it("should not be authorized if not admin", async () => {
+    const userJwt = app.get(JwtService).sign({ roles: [Role.User] });
+    console.log({ userJwt });
+    const response = await request(app.getHttpServer())
+      .post("/airdrop/upload/rewards")
+      .set({ Authorization: `Bearer ${userJwt}` });
+    expect(response.statusCode).toStrictEqual(403);
+  });
+
+  afterAll(async () => {});
+});
+
+afterAll(async () => {
+  await app.close();
+});

--- a/test/airdrop.e2e-spec.ts
+++ b/test/airdrop.e2e-spec.ts
@@ -120,8 +120,6 @@ describe("GET /airdrop/rewards", () => {
 });
 
 describe("POST /airdrop/upload/rewards", () => {
-  beforeAll(async () => {});
-
   it("should not be authorized if token is not attached", async () => {
     const response = await request(app.getHttpServer()).post("/airdrop/upload/rewards");
     expect(response.statusCode).toStrictEqual(401);
@@ -135,8 +133,6 @@ describe("POST /airdrop/upload/rewards", () => {
       .set({ Authorization: `Bearer ${userJwt}` });
     expect(response.statusCode).toStrictEqual(403);
   });
-
-  afterAll(async () => {});
 });
 
 afterAll(async () => {

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -33,16 +33,12 @@ beforeAll(async () => {
   await app.init();
 
   [existingUser, existingUser2] = await Promise.all([
-    app.get(UserService).createUserFromDiscordId(
-      mockUserEntity({
-        discordId: Date.now().toString(),
-      }),
-    ),
-    app.get(UserService).createUserFromDiscordId(
-      mockUserEntity({
-        discordId: (Date.now() - 1000).toString(),
-      }),
-    ),
+    app
+      .get(UserService)
+      .createOrUpdateUserFromDiscord({ discordAvatar: "avatar", discordId: "1", discordName: "name1" }),
+    app
+      .get(UserService)
+      .createOrUpdateUserFromDiscord({ discordAvatar: "avatar", discordId: "2", discordName: "name2" }),
   ]);
   validJwtForExistingUser = generateJwtForUser(existingUser);
   validJwtForExistingUser2 = generateJwtForUser(existingUser2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2624,7 +2624,17 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@*", "@types/express@^4.17.13":
+"@types/express@*":
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
+  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/express@^4.17.13":
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
   integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
@@ -2757,6 +2767,13 @@
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
+"@types/multer@^1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.7.tgz#89cf03547c28c7bbcc726f029e2a76a7232cc79e"
+  integrity sha512-/SNsDidUFCvqqcWDwxv2feww/yqhNeTRL5CVoL3jU4Goc4kKEL10T7Eye65ZqPNi4HRx8sAEX59pV1aEH7drNA==
+  dependencies:
+    "@types/express" "*"
 
 "@types/nanoid@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Changes:

- Add [models](https://github.com/across-protocol/scraper-api/tree/amatei/acx-290-add-endpoint-to-serve-wallet-rewards/src/modules/airdrop/model) for the Community Rewards and Wallet Rewards
- Add [endpoint](https://github.com/across-protocol/scraper-api/pull/84/files#diff-f91b21c92f2c60e94b5de8e3dcf5dc2b4bf31af44d40dc7c6d568ba1835f191eR13-R18) to get rewards for a particular wallet address
- Add [endpoint](https://github.com/across-protocol/scraper-api/pull/84/files#diff-f91b21c92f2c60e94b5de8e3dcf5dc2b4bf31af44d40dc7c6d568ba1835f191eR20-R42) to upload JSON files for populating the `community_rewards` and `wallet_rewards` tables
- Add a new [NestJS Guard](https://github.com/across-protocol/scraper-api/pull/84/files#diff-9acd83629deda2850757a03d3f6345dcc7e9583259d5b2ebfc795c99d941e461R13-R26) for RBAC authorization. Some endpoints (as uploading JSON rewards files) can be called only if the attached JWT has `admin` role
- Add [e2e test](https://github.com/across-protocol/scraper-api/blob/4a50e3d29d59257699a4b2f0c3d3526cb60cc288/test/airdrop.e2e-spec.ts)