### PR TITLE
fix: fetch community rewards by JWT claims

### DIFF
--- a/src/modules/airdrop/entry-points/http/controller.ts
+++ b/src/modules/airdrop/entry-points/http/controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Post, Query, UploadedFiles, UseGuards, UseInterceptors } from "@nestjs/common";
+import { Controller, Get, Post, Query, Req, UploadedFiles, UseGuards, UseInterceptors } from "@nestjs/common";
 import { FileFieldsInterceptor } from "@nestjs/platform-express";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
+import { OptionalJwtAuthGuard } from "../../../auth/entry-points/http/optional-jwt.";
 import { JwtAuthGuard } from "../../../auth/entry-points/http/jwt.guard";
 import { Role, Roles, RolesGuard } from "../../../auth/entry-points/http/roles";
 import { AirdropService } from "../../services/airdrop-service";
@@ -13,8 +14,9 @@ export class AirdropController {
   @Get("rewards")
   @ApiResponse({ type: GetAirdropRewardsResponse })
   @ApiTags("airdrop")
-  getAirdropRewards(@Query() query: GetAirdropRewardsQuery) {
-    return this.airdropService.getRewards(query.address);
+  @UseGuards(OptionalJwtAuthGuard)
+  getAirdropRewards(@Req() req: any, @Query() query: GetAirdropRewardsQuery) {
+    return this.airdropService.getRewards(query.address, req.user.id);
   }
 
   @Post("upload/rewards")

--- a/src/modules/airdrop/services/airdrop-service.ts
+++ b/src/modules/airdrop/services/airdrop-service.ts
@@ -26,10 +26,10 @@ export class AirdropService {
     private userService: UserService,
   ) {}
 
-  public async getRewards(walletAddress: string) {
+  public async getRewards(walletAddress: string, userId?: number) {
     const checksumAddress = ethers.utils.getAddress(walletAddress);
     const walletRewards = await this.getWalletRewards(checksumAddress);
-    const communityRewards: string = await this.getCommunityRewards(checksumAddress);
+    const communityRewards: string = await this.getCommunityRewards(userId);
     const welcomeTravellerEligible = !!walletRewards && new BigNumber(walletRewards.welcomeTravellerRewards).gt(0);
     let welcomeTravellerCompleted = false;
 
@@ -177,14 +177,13 @@ export class AirdropService {
     return this.walletRewardsRepository.findOne({ where: { walletAddress } });
   }
 
-  private async getCommunityRewards(walletAddress: string): Promise<string | undefined> {
-    const userWallet = await this.userWalletService.getUserWalletByAttributes({ walletAddress });
+  private async getCommunityRewards(userId?: number): Promise<string | undefined> {
+    if (!userId) return undefined;
+    const user = await this.userService.getUserByAttributes({ id: userId });
 
-    if (!userWallet) {
+    if (!user) {
       return undefined;
     }
-
-    const user = await this.userService.getUserByAttributes({ id: userWallet.userId });
     const communityRewards = await this.communityRewardsRepository.findOne({ where: { discordId: user.discordId } });
 
     if (!communityRewards) {

--- a/src/modules/airdrop/services/airdrop-service.ts
+++ b/src/modules/airdrop/services/airdrop-service.ts
@@ -29,7 +29,12 @@ export class AirdropService {
   public async getRewards(walletAddress: string, userId?: number) {
     const checksumAddress = ethers.utils.getAddress(walletAddress);
     const walletRewards = await this.getWalletRewards(checksumAddress);
-    const communityRewards: string = await this.getCommunityRewards(userId);
+    let communityRewards = undefined;
+
+    if (userId) {
+      communityRewards = await this.getCommunityRewards(userId);
+    }
+
     const welcomeTravellerEligible = !!walletRewards && new BigNumber(walletRewards.welcomeTravellerRewards).gt(0);
     let welcomeTravellerCompleted = false;
 
@@ -177,13 +182,13 @@ export class AirdropService {
     return this.walletRewardsRepository.findOne({ where: { walletAddress } });
   }
 
-  private async getCommunityRewards(userId?: number): Promise<string | undefined> {
-    if (!userId) return undefined;
+  private async getCommunityRewards(userId: number): Promise<string | undefined> {
     const user = await this.userService.getUserByAttributes({ id: userId });
 
     if (!user) {
       return undefined;
     }
+
     const communityRewards = await this.communityRewardsRepository.findOne({ where: { discordId: user.discordId } });
 
     if (!communityRewards) {

--- a/src/modules/auth/entry-points/http/optional-jwt..ts
+++ b/src/modules/auth/entry-points/http/optional-jwt..ts
@@ -1,0 +1,10 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard("jwt") {
+  // Override handleRequest so it never throws an error
+  handleRequest(err, user, info, context) {
+    return user;
+  }
+}


### PR DESCRIPTION
`/airdrop/rewards?address=0x...`: Now, in order to fetch the community rewards component, the JWT token needs to be attached to the req