### PR TITLE
fix: handle Discord auth error

### DIFF
--- a/src/modules/auth/adapters/discord/api.ts
+++ b/src/modules/auth/adapters/discord/api.ts
@@ -15,9 +15,14 @@ export class DiscordApiService {
   }
 
   public async getGuildUser(accessToken: string, guildId: string): Promise<DiscordGuildUser> {
-    const response = await this.http.axiosRef.get(`https://discordapp.com/api/users/@me/guilds/${guildId}/member`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    return response.data;
+    try {
+      const response = await this.http.axiosRef.get(`https://discordapp.com/api/users/@me/guilds/${guildId}/member`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      return response.data;
+    } catch (error) {
+      if (error?.response?.status === 404) return undefined;
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
https://linear.app/uma/issue/ACX-327/fix-discord-authentication

The discord auth endpoint throws an error if the user is not part of the Across Discord server. 
The correct flow is to ignore silently this error and use the global user details (name and avatar)