### PR TITLE
feat: inject and serve merkle distributor claims

### DIFF
--- a/migrations/1666019035195-MerkleDistributorWindow.ts
+++ b/migrations/1666019035195-MerkleDistributorWindow.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MerkleDistributorWindow1666019035195 implements MigrationInterface {
+  name = "MerkleDistributorWindow1666019035195";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "merkle_distributor_window" (
+        "id" SERIAL NOT NULL, 
+        "chainId" integer NOT NULL, 
+        "rewardToken" character varying NOT NULL, 
+        "windowIndex" integer NOT NULL, 
+        "rewardsToDeposit" numeric NOT NULL, 
+        "merkleRoot" character varying NOT NULL, 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "UK_merkle_distributor_window_windowIndex" UNIQUE ("windowIndex"), 
+        CONSTRAINT "PK_243dd06d9b7183bd8700e92129d" PRIMARY KEY ("id")
+      )`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "merkle_distributor_window"`);
+  }
+}

--- a/migrations/1666019035195-MerkleDistributorWindow.ts
+++ b/migrations/1666019035195-MerkleDistributorWindow.ts
@@ -12,6 +12,7 @@ export class MerkleDistributorWindow1666019035195 implements MigrationInterface 
         "windowIndex" integer NOT NULL, 
         "rewardsToDeposit" numeric NOT NULL, 
         "merkleRoot" character varying NOT NULL, 
+        "ipfsHash" character varying,
         "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
         CONSTRAINT "UK_merkle_distributor_window_windowIndex" UNIQUE ("windowIndex"), 
         CONSTRAINT "PK_243dd06d9b7183bd8700e92129d" PRIMARY KEY ("id")

--- a/migrations/1666019035196-MerkleDistributorRecipient.ts
+++ b/migrations/1666019035196-MerkleDistributorRecipient.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MerkleDistributorRecipient1666019035196 implements MigrationInterface {
+  name = "MerkleDistributorRecipient1666019035196";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "merkle_distributor_recipient" (
+        "id" SERIAL NOT NULL, 
+        "merkleDistributorWindowId" integer NOT NULL, 
+        "address" character varying NOT NULL, 
+        "amount" numeric NOT NULL, 
+        "accountIndex" integer NOT NULL, 
+        "proof" jsonb NOT NULL, 
+        "payload" jsonb NOT NULL, 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "UK_merkle_distributor_recipient_merkleDistributorWindowId_address" UNIQUE ("merkleDistributorWindowId", "address"), 
+        CONSTRAINT "PK_4e2e34ff4eb70d9debea9693f78" PRIMARY KEY ("id")
+      )`);
+    await queryRunner.query(`
+      ALTER TABLE "merkle_distributor_recipient" 
+      ADD CONSTRAINT "FK_0074cbd24d2a7f96158633c4534" 
+        FOREIGN KEY ("merkleDistributorWindowId") 
+        REFERENCES "merkle_distributor_window"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "merkle_distributor_recipient" 
+      DROP CONSTRAINT "FK_0074cbd24d2a7f96158633c4534"
+    `);
+    await queryRunner.query(`DROP TABLE "merkle_distributor_recipient"`);
+  }
+}

--- a/src/modules/airdrop/adapter/db/merkle-distributor-recipient.ts
+++ b/src/modules/airdrop/adapter/db/merkle-distributor-recipient.ts
@@ -1,0 +1,44 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { MerkleDistributorRecipient } from "../../model/merkle-distributor-recipient.entity";
+
+@Injectable()
+export class MerkleDistributorRecipientFixture {
+  public constructor(
+    @InjectRepository(MerkleDistributorRecipient)
+    private merkleDistributorRecipientRepository: Repository<MerkleDistributorRecipient>,
+  ) {}
+
+  public insertMerkleDistributorRecipient(args: Partial<MerkleDistributorRecipient> = {}) {
+    const deposit = this.merkleDistributorRecipientRepository.create(this.mockMerkleDistributorRecipientEntity(args));
+    return this.merkleDistributorRecipientRepository.save(deposit);
+  }
+
+  public insertManyMerkleDistributorRecipients(args: Partial<MerkleDistributorRecipient>[] = [{}]) {
+    const createdDeposits = this.merkleDistributorRecipientRepository.create(
+      args.map((arg) => this.mockMerkleDistributorRecipientEntity(arg)),
+    );
+    return this.merkleDistributorRecipientRepository.save(createdDeposits);
+  }
+
+  public mockMerkleDistributorRecipientEntity(
+    overrides: Partial<MerkleDistributorRecipient> = {},
+  ): Partial<MerkleDistributorRecipient> {
+    return {
+      merkleDistributorWindowId: 0,
+      address: "0x",
+      amount: "10",
+      accountIndex: 0,
+      proof: ["ox"],
+      payload: {},
+      ...overrides,
+    };
+  }
+
+  public deleteAllMerkleDistributorRecipients() {
+    return this.merkleDistributorRecipientRepository.query(
+      `truncate table "merkle_distributor_recipient" restart identity cascade`,
+    );
+  }
+}

--- a/src/modules/airdrop/adapter/db/merkle-distributor-window-fixture.ts
+++ b/src/modules/airdrop/adapter/db/merkle-distributor-window-fixture.ts
@@ -1,0 +1,43 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { MerkleDistributorWindow } from "../../model/merkle-distributor-window.entity";
+
+@Injectable()
+export class MerkleDistributorWindowFixture {
+  public constructor(
+    @InjectRepository(MerkleDistributorWindow)
+    private merkleDistributorWindowRepository: Repository<MerkleDistributorWindow>,
+  ) {}
+
+  public insertMerkleDistributorWindow(args: Partial<MerkleDistributorWindow> = {}) {
+    const deposit = this.merkleDistributorWindowRepository.create(this.mockMerkleDistributorWindowEntity(args));
+    return this.merkleDistributorWindowRepository.save(deposit);
+  }
+
+  public insertManyMerkleDistributorWindows(args: Partial<MerkleDistributorWindow>[] = [{}]) {
+    const createdDeposits = this.merkleDistributorWindowRepository.create(
+      args.map((arg) => this.mockMerkleDistributorWindowEntity(arg)),
+    );
+    return this.merkleDistributorWindowRepository.save(createdDeposits);
+  }
+
+  public mockMerkleDistributorWindowEntity(
+    overrides: Partial<MerkleDistributorWindow> = {},
+  ): Partial<MerkleDistributorWindow> {
+    return {
+      chainId: 1,
+      rewardToken: "0x",
+      windowIndex: 0,
+      rewardsToDeposit: "10",
+      merkleRoot: "0x",
+      ...overrides,
+    };
+  }
+
+  public deleteAllMerkleDistributorWindows() {
+    return this.merkleDistributorWindowRepository.query(
+      `truncate table "merkle_distributor_window" restart identity cascade`,
+    );
+  }
+}

--- a/src/modules/airdrop/entry-points/http/controller.ts
+++ b/src/modules/airdrop/entry-points/http/controller.ts
@@ -84,6 +84,7 @@ export class AirdropController {
   @Get("merkle-distributor-proof")
   @ApiTags("airdrop")
   getMerkleDistributorProof(@Query() query: GetMerkleDistributorProofQuery) {
-    return this.airdropService.getMerkleDistributorProof(query.address, query.windowIndex);
+    const includeDiscord = query.includeDiscord === "true";
+    return this.airdropService.getMerkleDistributorProof(query.address, query.windowIndex, includeDiscord);
   }
 }

--- a/src/modules/airdrop/entry-points/http/controller.ts
+++ b/src/modules/airdrop/entry-points/http/controller.ts
@@ -17,7 +17,12 @@ import { OptionalJwtAuthGuard } from "../../../auth/entry-points/http/optional-j
 import { JwtAuthGuard } from "../../../auth/entry-points/http/jwt.guard";
 import { Role, Roles, RolesGuard } from "../../../auth/entry-points/http/roles";
 import { AirdropService } from "../../services/airdrop-service";
-import { EditWalletRewardsBody, GetAirdropRewardsQuery, GetAirdropRewardsResponse, GetMerkleDistributorProofQuery } from "./dto";
+import {
+  EditWalletRewardsBody,
+  GetAirdropRewardsQuery,
+  GetAirdropRewardsResponse,
+  GetMerkleDistributorProofQuery,
+} from "./dto";
 
 @Controller("airdrop")
 export class AirdropController {

--- a/src/modules/airdrop/entry-points/http/dto.ts
+++ b/src/modules/airdrop/entry-points/http/dto.ts
@@ -58,3 +58,11 @@ export class EditWalletRewardsBody {
   @IsNumberString({ no_symbols: true })
   welcomeTravellerRewards: string;
 }
+
+export class GetMerkleDistributorProofQuery {
+  @IsNumberString()
+  windowIndex: number;
+
+  @IsEthereumAddress()
+  address: string;
+}

--- a/src/modules/airdrop/entry-points/http/dto.ts
+++ b/src/modules/airdrop/entry-points/http/dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEthereumAddress, IsNumberString, IsString, Length } from "class-validator";
+import { IsEnum, IsEthereumAddress, IsNumberString, IsOptional, IsString, Length } from "class-validator";
 
 export class GetAirdropRewardsQuery {
   @IsString()
@@ -59,10 +59,15 @@ export class EditWalletRewardsBody {
   welcomeTravellerRewards: string;
 }
 
+export const IncludeDiscordQueryValues = ["true", "false"] as const;
 export class GetMerkleDistributorProofQuery {
   @IsNumberString()
   windowIndex: number;
 
   @IsEthereumAddress()
   address: string;
+
+  @IsEnum(IncludeDiscordQueryValues)
+  @IsOptional()
+  includeDiscord: typeof IncludeDiscordQueryValues[number];
 }

--- a/src/modules/airdrop/model/merkle-distributor-recipient.entity.ts
+++ b/src/modules/airdrop/model/merkle-distributor-recipient.entity.ts
@@ -1,0 +1,43 @@
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, Unique } from "typeorm";
+import { MerkleDistributorWindow } from "./merkle-distributor-window.entity";
+
+export type MerkleDistributorRecipientPayload = {
+  amountBreakdown?: {
+    communityRewards: string;
+    liquidityProviderRewards: string;
+    earlyUserRewards: string;
+    welcomeTravelerRewards: string;
+  };
+};
+
+@Entity()
+// A recipient address can't appear twice for the same window
+@Unique("UK_merkle_distributor_recipient_merkleDistributorWindowId_address", ["merkleDistributorWindowId", "address"])
+export class MerkleDistributorRecipient {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  merkleDistributorWindowId: number;
+
+  @ManyToOne(() => MerkleDistributorWindow, (window) => window.recipients)
+  merkleDistributorWindow: MerkleDistributorWindow;
+
+  @Column()
+  address: string;
+
+  @Column({ type: "decimal" })
+  amount: string;
+
+  @Column()
+  accountIndex: number;
+
+  @Column({ type: "jsonb" })
+  proof: string[];
+
+  @Column({ type: "jsonb" })
+  payload: MerkleDistributorRecipientPayload;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/modules/airdrop/model/merkle-distributor-window.entity.ts
+++ b/src/modules/airdrop/model/merkle-distributor-window.entity.ts
@@ -1,0 +1,31 @@
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, Unique } from "typeorm";
+import { MerkleDistributorRecipient } from "./merkle-distributor-recipient.entity";
+
+@Entity()
+// Don't allow duplicates of the window index
+@Unique("UK_merkle_distributor_window_windowIndex", ["windowIndex"])
+export class MerkleDistributorWindow {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  chainId: number;
+
+  @Column()
+  rewardToken: string;
+
+  @Column()
+  windowIndex: number;
+
+  @Column({ type: "decimal" })
+  rewardsToDeposit: string;
+
+  @Column()
+  merkleRoot: string;
+
+  @OneToMany(() => MerkleDistributorRecipient, (recipient) => recipient.merkleDistributorWindow)
+  recipients: MerkleDistributorRecipient;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/modules/airdrop/model/merkle-distributor-window.entity.ts
+++ b/src/modules/airdrop/model/merkle-distributor-window.entity.ts
@@ -23,6 +23,9 @@ export class MerkleDistributorWindow {
   @Column()
   merkleRoot: string;
 
+  @Column({ nullable: true })
+  ipfsHash?: string;
+
   @OneToMany(() => MerkleDistributorRecipient, (recipient) => recipient.merkleDistributorWindow)
   recipients: MerkleDistributorRecipient;
 

--- a/src/modules/airdrop/module.ts
+++ b/src/modules/airdrop/module.ts
@@ -12,11 +12,31 @@ import { AirdropController } from "./entry-points/http/controller";
 import { CommunityRewards } from "./model/community-rewards.entity";
 import { WalletRewards } from "./model/wallet-rewards.entity";
 import { Deposit } from "../scraper/model/deposit.entity";
+import { MerkleDistributorWindowFixture } from "./adapter/db/merkle-distributor-window-fixture";
+import { MerkleDistributorWindow } from "./model/merkle-distributor-window.entity";
+import { MerkleDistributorRecipient } from "./model/merkle-distributor-recipient.entity";
+import { MerkleDistributorRecipientFixture } from "./adapter/db/merkle-distributor-recipient";
 
 @Module({
-  providers: [AirdropService, WalletRewardsFixture, CommunityRewardsFixture],
+  providers: [
+    AirdropService,
+    WalletRewardsFixture,
+    CommunityRewardsFixture,
+    MerkleDistributorWindowFixture,
+    MerkleDistributorRecipientFixture,
+  ],
   controllers: [AirdropController],
-  imports: [TypeOrmModule.forFeature([CommunityRewards, WalletRewards, Deposit]), UserModule, AppConfigModule],
+  imports: [
+    TypeOrmModule.forFeature([
+      CommunityRewards,
+      WalletRewards,
+      Deposit,
+      MerkleDistributorWindow,
+      MerkleDistributorRecipient,
+    ]),
+    UserModule,
+    AppConfigModule,
+  ],
   exports: [],
 })
 export class AirdropModule {}

--- a/src/modules/airdrop/services/airdrop-service.ts
+++ b/src/modules/airdrop/services/airdrop-service.ts
@@ -150,6 +150,7 @@ export class AirdropService {
             windowIndex: recipientsJson["windowIndex"],
             rewardsToDeposit: recipientsJson["rewardsToDeposit"],
             merkleRoot: recipientsJson["merkleRoot"],
+            ipfsHash: recipientsJson["ipfsHash"],
           })
           .execute();
         const windowId = window.identifiers[0].id;
@@ -212,6 +213,7 @@ export class AirdropService {
       proof: recipient.proof,
       merkleRoot: recipient.merkleDistributorWindow.merkleRoot,
       windowIndex: recipient.merkleDistributorWindow.windowIndex,
+      ipfsHash: recipient.merkleDistributorWindow.ipfsHash || null,
     };
   }
 

--- a/src/modules/airdrop/services/exceptions.ts
+++ b/src/modules/airdrop/services/exceptions.ts
@@ -23,3 +23,15 @@ export class ProcessWalletRewardsFileException extends HttpException {
     );
   }
 }
+
+export class DuplicatedMerkleDistributorWindowException extends HttpException {
+  constructor() {
+    super(
+      {
+        error: DuplicatedMerkleDistributorWindowException.name,
+        message: "The window index already exists in the database",
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}

--- a/src/modules/database/database.providers.ts
+++ b/src/modules/database/database.providers.ts
@@ -11,6 +11,8 @@ import { User } from "../user/model/user.entity";
 import { WalletRewards } from "../airdrop/model/wallet-rewards.entity";
 import { CommunityRewards } from "../airdrop/model/community-rewards.entity";
 import { UserWallet } from "../user/model/user-wallet.entity";
+import { MerkleDistributorRecipient } from "../airdrop/model/merkle-distributor-recipient.entity";
+import { MerkleDistributorWindow } from "../airdrop/model/merkle-distributor-window.entity";
 
 // TODO: Add db entities here
 const entities = [
@@ -24,6 +26,8 @@ const entities = [
   WalletRewards,
   CommunityRewards,
   UserWallet,
+  MerkleDistributorWindow,
+  MerkleDistributorRecipient,
 ];
 
 @Injectable()

--- a/test/airdrop/merkle-distributor-duplicate-window.json
+++ b/test/airdrop/merkle-distributor-duplicate-window.json
@@ -1,0 +1,8 @@
+{
+  "chainId": 1,
+  "rewardToken": "0x40153DdFAd90C49dbE3F5c9F96f2a5B25ec67461",
+  "windowIndex": 0,
+  "rewardsToDeposit": "40",
+  "merkleRoot": "0x22d3a95c82f748d96d4bd698bf1177d0ce98aab22f9a8410a870544f465cb8c8",
+  "recipientsWithProofs": {}
+}

--- a/test/airdrop/merkle-distributor.e2e-spec.ts
+++ b/test/airdrop/merkle-distributor.e2e-spec.ts
@@ -1,0 +1,181 @@
+import { INestApplication } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { Test } from "@nestjs/testing";
+import { Role } from "../../src/modules/auth/entry-points/http/roles";
+import { configValues } from "../../src/modules/configuration";
+import request from "supertest";
+import { AppModule } from "../../src/app.module";
+import { ValidationPipe } from "../../src/validation.pipe";
+import { MerkleDistributorWindowFixture } from "../../src/modules/airdrop/adapter/db/merkle-distributor-window-fixture";
+import { MerkleDistributorRecipientFixture } from "../../src/modules/airdrop/adapter/db/merkle-distributor-recipient";
+
+let app: INestApplication;
+let merkleDistributorWindowFixture: MerkleDistributorWindowFixture;
+let merkleDistributorRecipientFixture: MerkleDistributorRecipientFixture;
+
+beforeAll(async () => {
+  const moduleFixture = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  app = moduleFixture.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe());
+  await app.init();
+
+  merkleDistributorWindowFixture = app.get(MerkleDistributorWindowFixture);
+  merkleDistributorRecipientFixture = app.get(MerkleDistributorRecipientFixture);
+});
+
+describe("GET /airdrop/merkle-distributor-proof", () => {
+  const url = "/airdrop/merkle-distributor-proof";
+
+  afterEach(async () => {
+    await merkleDistributorWindowFixture.deleteAllMerkleDistributorWindows();
+    await merkleDistributorRecipientFixture.deleteAllMerkleDistributorRecipients();
+  });
+
+  it("should get the merkle proof", async () => {
+    const address = "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd";
+    const window = await merkleDistributorWindowFixture.insertMerkleDistributorWindow({
+      merkleRoot: "0xmerkleroot",
+      windowIndex: 0,
+      rewardToken: "0xrewardtoken",
+      rewardsToDeposit: "10",
+    });
+    await merkleDistributorRecipientFixture.insertMerkleDistributorRecipient({
+      accountIndex: 0,
+      address,
+      amount: "10",
+      merkleDistributorWindowId: window.id,
+      proof: ["0xproof"],
+      payload: {
+        amountBreakdown: {
+          communityRewards: "2",
+          earlyUserRewards: "2",
+          liquidityProviderRewards: "2",
+          welcomeTravelerRewards: "4",
+        },
+      },
+    });
+    const response = await request(app.getHttpServer()).get(url).query({
+      address,
+      windowIndex: 0,
+    });
+    expect(response.statusCode).toStrictEqual(200);
+    expect(response.body.address).toStrictEqual(address);
+    expect(response.body.windowIndex).toStrictEqual(0);
+  });
+
+  it("should return empty if window index is incorrect", async () => {
+    const address = "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd";
+    const window = await merkleDistributorWindowFixture.insertMerkleDistributorWindow({
+      merkleRoot: "0xmerkleroot",
+      windowIndex: 0,
+      rewardToken: "0xrewardtoken",
+      rewardsToDeposit: "10",
+    });
+    await merkleDistributorRecipientFixture.insertMerkleDistributorRecipient({
+      accountIndex: 0,
+      address,
+      amount: "10",
+      merkleDistributorWindowId: window.id,
+      proof: ["0xproof"],
+      payload: {
+        amountBreakdown: {
+          communityRewards: "2",
+          earlyUserRewards: "2",
+          liquidityProviderRewards: "2",
+          welcomeTravelerRewards: "4",
+        },
+      },
+    });
+    const response = await request(app.getHttpServer()).get(url).query({
+      address,
+      windowIndex: 1,
+    });
+    expect(response.statusCode).toStrictEqual(200);
+    expect(response.body).toStrictEqual({});
+  });
+
+  it("should return empty if account is incorrect", async () => {
+    const address = "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd";
+    const window = await merkleDistributorWindowFixture.insertMerkleDistributorWindow({
+      merkleRoot: "0xmerkleroot",
+      windowIndex: 0,
+      rewardToken: "0xrewardtoken",
+      rewardsToDeposit: "10",
+    });
+    await merkleDistributorRecipientFixture.insertMerkleDistributorRecipient({
+      accountIndex: 0,
+      address,
+      amount: "10",
+      merkleDistributorWindowId: window.id,
+      proof: ["0xproof"],
+      payload: {
+        amountBreakdown: {
+          communityRewards: "2",
+          earlyUserRewards: "2",
+          liquidityProviderRewards: "2",
+          welcomeTravelerRewards: "4",
+        },
+      },
+    });
+    const response = await request(app.getHttpServer()).get(url).query({
+      address: "0x717DCF5FEF335c8f0A9b864859EF0734dFe3D2c3",
+      windowIndex: 0,
+    });
+    expect(response.statusCode).toStrictEqual(200);
+    expect(response.body).toStrictEqual({});
+  });
+});
+
+describe("POST /airdrop/upload/merkle-distributor-recipients", () => {
+  const url = "/airdrop/upload/merkle-distributor-recipients";
+
+  afterEach(async () => {
+    await merkleDistributorWindowFixture.deleteAllMerkleDistributorWindows();
+    await merkleDistributorRecipientFixture.deleteAllMerkleDistributorRecipients();
+  });
+
+  it("should not be authorized if JWT is not attached", async () => {
+    const response = await request(app.getHttpServer()).post(url);
+    expect(response.statusCode).toStrictEqual(401);
+  });
+
+  it("should error if JWT doesn't have admin role", async () => {
+    const userJwt = app.get(JwtService).sign({ roles: [Role.User] }, { secret: configValues().auth.jwtSecret });
+    const response = await request(app.getHttpServer())
+      .post(url)
+      .set({ Authorization: `Bearer ${userJwt}` });
+    expect(response.statusCode).toStrictEqual(403);
+  });
+
+  it("should error for duplicated windows", async () => {
+    const jwt = app.get(JwtService).sign({ roles: [Role.Admin] }, { secret: configValues().auth.jwtSecret });
+    let response = await request(app.getHttpServer())
+      .post(url)
+      .attach("file", __dirname + "/merkle-distributor-duplicate-window.json")
+      .set({ Authorization: `Bearer ${jwt}` });
+    expect(response.statusCode).toStrictEqual(201);
+    response = await request(app.getHttpServer())
+      .post(url)
+      .attach("file", __dirname + "/merkle-distributor-duplicate-window.json")
+      .set({ Authorization: `Bearer ${jwt}` });
+    expect(response.statusCode).toStrictEqual(400);
+    expect(response.body.error).toStrictEqual("DuplicatedMerkleDistributorWindowException");
+  });
+
+  it("should work successfully", async () => {
+    const jwt = app.get(JwtService).sign({ roles: [Role.Admin] }, { secret: configValues().auth.jwtSecret });
+    const response = await request(app.getHttpServer())
+      .post(url)
+      .attach("file", __dirname + "/merkle-distributor.json")
+      .set({ Authorization: `Bearer ${jwt}` });
+    expect(response.statusCode).toStrictEqual(201);
+    expect(response.body.recipients).toStrictEqual(2);
+  });
+});
+
+afterAll(async () => {
+  await app.close();
+});

--- a/test/airdrop/merkle-distributor.json
+++ b/test/airdrop/merkle-distributor.json
@@ -1,0 +1,43 @@
+{
+  "chainId": 1,
+  "rewardToken": "0x40153DdFAd90C49dbE3F5c9F96f2a5B25ec67461",
+  "windowIndex": 0,
+  "rewardsToDeposit": "40",
+  "merkleRoot": "0x22d3a95c82f748d96d4bd698bf1177d0ce98aab22f9a8410a870544f465cb8c8",
+  "recipientsWithProofs": {
+    "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3ac": {
+      "metadata": {
+        "amountBreakdown": {
+          "communityRewards": "5",
+          "liquidityProviderRewards": "0",
+          "earlyUserRewards": "0",
+          "welcomeTravelerRewards": "5"
+        }
+      },
+      "account": "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3ac",
+      "amount": "10",
+      "accountIndex": 0,
+      "proof": [
+        "0x939b447f774f79401f5551d9b457e92a05a9ea27505739b2aefc7490f026dcba"
+      ],
+      "windowIndex": 0
+    },
+    "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd": {
+      "metadata": {
+        "amountBreakdown": {
+          "communityRewards": "5",
+          "liquidityProviderRewards": "0",
+          "earlyUserRewards": "0",
+          "welcomeTravelerRewards": "5"
+        }
+      },
+      "account": "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd",
+      "amount": "10",
+      "accountIndex": 0,
+      "proof": [
+        "0x939b447f774f79401f5551d9b457e92a05a9ea27505739b2aefc7490f026dcba"
+      ],
+      "windowIndex": 0
+    }
+  }
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,6 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "verbose": true
 }


### PR DESCRIPTION
https://linear.app/uma/issue/ACX-352/scraper-api-endpoint-for-handling-created-tree

Changes in this PR:
- add [MerkleDistributorRecipient](https://github.com/across-protocol/scraper-api/blob/758d5a9d732533a25cc17e3f745e95e18bcb5d8d/src/modules/airdrop/model/merkle-distributor-recipient.entity.ts) and [MerkleDistributorWindow](https://github.com/across-protocol/scraper-api/blob/758d5a9d732533a25cc17e3f745e95e18bcb5d8d/src/modules/airdrop/model/merkle-distributor-window.entity.ts) entities
- [endpoint](https://github.com/across-protocol/scraper-api/blob/758d5a9d732533a25cc17e3f745e95e18bcb5d8d/src/modules/airdrop/entry-points/http/controller.ts#L65-L77) to upload JSON file for MerkleDistributor recipients (this endpoint is intended to be called by the [merkle-distributor publish-tree script](https://github.com/across-protocol/merkle-distributor/blob/main/scripts/publish-tree.ts))
- [endpoint](https://github.com/across-protocol/scraper-api/blob/758d5a9d732533a25cc17e3f745e95e18bcb5d8d/src/modules/airdrop/entry-points/http/controller.ts#L79-L83) to serve the claims for the MerkleDistributor contract
- add [e2e tests](https://github.com/across-protocol/scraper-api/blob/758d5a9d732533a25cc17e3f745e95e18bcb5d8d/test/airdrop/merkle-distributor.e2e-spec.ts)