### PR TITLE
fix: improve referrals consumer (stage)

### DIFF
--- a/src/modules/scraper/adapter/messaging/DepositReferralConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/DepositReferralConsumer.ts
@@ -49,14 +49,20 @@ export class DepositReferralConsumer {
       }
     }
 
-    await this.depositRepository.update({ id: deposit.id }, { referralAddress: referralAddress || null });
+    await this.depositRepository.update(
+      { id: deposit.id },
+      { referralAddress: referralAddress || null, stickyReferralAddress: referralAddress || null },
+    );
 
-    if (this.appConfig.values.stickyReferralAddressesMechanism === StickyReferralAddressesMechanism.Queue) {
+    if (!referralAddress) {
       const hasDepositsWithReferrals = await this.depositRepository.findOne({
         where: { depositorAddr: deposit.depositorAddr, referralAddress: Not(IsNull()) },
       });
 
-      if (hasDepositsWithReferrals) {
+      if (
+        this.appConfig.values.stickyReferralAddressesMechanism === StickyReferralAddressesMechanism.Queue &&
+        hasDepositsWithReferrals
+      ) {
         await this.depositRepository.query(updateStickyReferralAddressesForDepositor(), [deposit.depositorAddr]);
       }
     }


### PR DESCRIPTION
This PR improves the speed of the consumer that extracts the referral address and computes the sticky referral addresses. The query that computes the sticky referral addresses will now run only if the txn data doesn't contain a referral address