### PR TITLE
feat: GET /merkle-distributor-proofs

### DIFF
--- a/src/modules/airdrop/entry-points/http/controller.ts
+++ b/src/modules/airdrop/entry-points/http/controller.ts
@@ -22,6 +22,7 @@ import {
   GetAirdropRewardsQuery,
   GetAirdropRewardsResponse,
   GetMerkleDistributorProofQuery,
+  GetMerkleDistributorProofsQuery,
 } from "./dto";
 
 @Controller("airdrop")
@@ -86,5 +87,11 @@ export class AirdropController {
   getMerkleDistributorProof(@Query() query: GetMerkleDistributorProofQuery) {
     const includeDiscord = query.includeDiscord === "true";
     return this.airdropService.getMerkleDistributorProof(query.address, query.windowIndex, includeDiscord);
+  }
+
+  @Get("merkle-distributor-proofs")
+  @ApiTags("airdrop")
+  getMerkleDistributorProofs(@Query() query: GetMerkleDistributorProofsQuery) {
+    return this.airdropService.getMerkleDistributorProofs(query.address, query.startWindowIndex);
   }
 }

--- a/src/modules/airdrop/entry-points/http/dto.ts
+++ b/src/modules/airdrop/entry-points/http/dto.ts
@@ -71,3 +71,12 @@ export class GetMerkleDistributorProofQuery {
   @IsOptional()
   includeDiscord: typeof IncludeDiscordQueryValues[number];
 }
+
+export class GetMerkleDistributorProofsQuery {
+  @IsNumberString()
+  @IsOptional()
+  startWindowIndex: number;
+
+  @IsEthereumAddress()
+  address: string;
+}

--- a/src/modules/airdrop/model/merkle-distributor-recipient.entity.ts
+++ b/src/modules/airdrop/model/merkle-distributor-recipient.entity.ts
@@ -7,6 +7,7 @@ export type MerkleDistributorRecipientPayload = {
     liquidityProviderRewards: string;
     earlyUserRewards: string;
     welcomeTravelerRewards: string;
+    referralRewards: string;
   };
 };
 

--- a/test/airdrop/merkle-distributor.e2e-spec.ts
+++ b/test/airdrop/merkle-distributor.e2e-spec.ts
@@ -62,6 +62,7 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
           earlyUserRewards: "2",
           liquidityProviderRewards: "2",
           welcomeTravelerRewards: "4",
+          referralRewards: "0",
         },
       },
     });
@@ -101,6 +102,7 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
           earlyUserRewards: "2",
           liquidityProviderRewards: "2",
           welcomeTravelerRewards: "4",
+          referralRewards: "0",
         },
       },
     });
@@ -139,6 +141,7 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
           earlyUserRewards: "2",
           liquidityProviderRewards: "2",
           welcomeTravelerRewards: "4",
+          referralRewards: "0",
         },
       },
     });
@@ -170,6 +173,7 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
           earlyUserRewards: "2",
           liquidityProviderRewards: "2",
           welcomeTravelerRewards: "4",
+          referralRewards: "0",
         },
       },
     });
@@ -211,10 +215,11 @@ describe("GET /airdrop/merkle-distributor-proofs", () => {
         proof: ["0xproof"],
         payload: {
           amountBreakdown: {
-            communityRewards: "2",
-            earlyUserRewards: "2",
-            liquidityProviderRewards: "2",
-            welcomeTravelerRewards: "4",
+            communityRewards: "0",
+            earlyUserRewards: "0",
+            liquidityProviderRewards: "0",
+            welcomeTravelerRewards: "0",
+            referralRewards: "10",
           },
         },
       },
@@ -226,10 +231,11 @@ describe("GET /airdrop/merkle-distributor-proofs", () => {
         proof: ["0xproof"],
         payload: {
           amountBreakdown: {
-            communityRewards: "2",
-            earlyUserRewards: "2",
-            liquidityProviderRewards: "2",
-            welcomeTravelerRewards: "4",
+            communityRewards: "0",
+            earlyUserRewards: "0",
+            liquidityProviderRewards: "0",
+            welcomeTravelerRewards: "0",
+            referralRewards: "10",
           },
         },
       },
@@ -264,7 +270,7 @@ describe("GET /airdrop/merkle-distributor-proofs", () => {
       startWindowIndex: 1000,
     });
     expect(response.statusCode).toStrictEqual(200);
-    expect(response.body.length).toStrictEqual(1);
+    expect(response.body.length).toStrictEqual(0);
   });
 });
 

--- a/test/airdrop/merkle-distributor.e2e-spec.ts
+++ b/test/airdrop/merkle-distributor.e2e-spec.ts
@@ -182,6 +182,92 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
   });
 });
 
+describe("GET /airdrop/merkle-distributor-proofs", () => {
+  const url = "/airdrop/merkle-distributor-proofs";
+
+  const address = "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd";
+
+  beforeAll(async () => {
+    const windows = await merkleDistributorWindowFixture.insertManyMerkleDistributorWindows([
+      {
+        merkleRoot: "0xmerkleroot",
+        windowIndex: 0,
+        rewardToken: "0xrewardtoken",
+        rewardsToDeposit: "10",
+      },
+      {
+        merkleRoot: "0xmerkleroot",
+        windowIndex: 1,
+        rewardToken: "0xrewardtoken",
+        rewardsToDeposit: "10",
+      },
+    ]);
+    await merkleDistributorRecipientFixture.insertManyMerkleDistributorRecipients([
+      {
+        accountIndex: 0,
+        address,
+        amount: "10",
+        merkleDistributorWindowId: windows[0].id,
+        proof: ["0xproof"],
+        payload: {
+          amountBreakdown: {
+            communityRewards: "2",
+            earlyUserRewards: "2",
+            liquidityProviderRewards: "2",
+            welcomeTravelerRewards: "4",
+          },
+        },
+      },
+      {
+        accountIndex: 0,
+        address,
+        amount: "10",
+        merkleDistributorWindowId: windows[1].id,
+        proof: ["0xproof"],
+        payload: {
+          amountBreakdown: {
+            communityRewards: "2",
+            earlyUserRewards: "2",
+            liquidityProviderRewards: "2",
+            welcomeTravelerRewards: "4",
+          },
+        },
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await merkleDistributorWindowFixture.deleteAllMerkleDistributorWindows();
+    await merkleDistributorRecipientFixture.deleteAllMerkleDistributorRecipients();
+  });
+
+  it("should return all merkle proofs", async () => {
+    const response = await request(app.getHttpServer()).get(url).query({
+      address,
+    });
+    expect(response.statusCode).toStrictEqual(200);
+    expect(response.body.length).toStrictEqual(2);
+  });
+
+  it("should return 1 merkle proof", async () => {
+    const response = await request(app.getHttpServer()).get(url).query({
+      address,
+      startWindowIndex: 1,
+    });
+    expect(response.statusCode).toStrictEqual(200);
+    expect(response.body.length).toStrictEqual(1);
+  });
+
+  it("should return no merkle proofs", async () => {
+    const response = await request(app.getHttpServer()).get(url).query({
+      address,
+      startWindowIndex: 1000,
+    });
+    expect(response.statusCode).toStrictEqual(200);
+    expect(response.body.length).toStrictEqual(1);
+  });
+});
+
 describe("POST /airdrop/upload/merkle-distributor-recipients", () => {
   const url = "/airdrop/upload/merkle-distributor-recipients";
 

--- a/test/airdrop/merkle-distributor.json
+++ b/test/airdrop/merkle-distributor.json
@@ -11,15 +11,14 @@
           "communityRewards": "5",
           "liquidityProviderRewards": "0",
           "earlyUserRewards": "0",
-          "welcomeTravelerRewards": "5"
+          "welcomeTravelerRewards": "5",
+          "referralRewards": "0"
         }
       },
       "account": "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3ac",
       "amount": "10",
       "accountIndex": 0,
-      "proof": [
-        "0x939b447f774f79401f5551d9b457e92a05a9ea27505739b2aefc7490f026dcba"
-      ],
+      "proof": ["0x939b447f774f79401f5551d9b457e92a05a9ea27505739b2aefc7490f026dcba"],
       "windowIndex": 0
     },
     "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd": {
@@ -28,15 +27,14 @@
           "communityRewards": "5",
           "liquidityProviderRewards": "0",
           "earlyUserRewards": "0",
-          "welcomeTravelerRewards": "5"
+          "welcomeTravelerRewards": "5",
+          "referralRewards": "0"
         }
       },
       "account": "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd",
       "amount": "10",
       "accountIndex": 0,
-      "proof": [
-        "0x939b447f774f79401f5551d9b457e92a05a9ea27505739b2aefc7490f026dcba"
-      ],
+      "proof": ["0x939b447f774f79401f5551d9b457e92a05a9ea27505739b2aefc7490f026dcba"],
       "windowIndex": 0
     }
   }


### PR DESCRIPTION
Add endpoint to retrieve all registered proofs for a given address. This is required for the referrals claiming. Also extends the payload of the recipients file to allow referral rewards as metadata.

Corresponding MerkleDistributor scripts PR https://github.com/across-protocol/merkle-distributor/pull/5