### PR TITLE
fix: typeerror when enable spokepool events processing (stage)

### DIFF
--- a/src/modules/scraper/service.ts
+++ b/src/modules/scraper/service.ts
@@ -117,7 +117,11 @@ export class ScraperService {
 
     for (const chainIdStr of Object.keys(latestBlocks)) {
       const chainId = parseInt(chainIdStr);
-      const configStartBlockNumber = startBlockNumbers[chainId].startBlockNumber;
+      const configStartBlockNumber = startBlockNumbers[chainId]?.startBlockNumber;
+
+      if (!configStartBlockNumber) {
+        continue;
+      }
 
       const blockRange = await this.determineBlockRange(
         chainId,


### PR DESCRIPTION
The app crashed when a provider was configured, e.g. goerli, that didn't have a spokepool configured.