### PR TITLE
fix: improve avg fill time (stage)

### DIFF
--- a/migrations/1668339782209-Deposit.ts
+++ b/migrations/1668339782209-Deposit.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Deposit1668339782209 implements MigrationInterface {
+  name = "Deposit1668339782209";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "deposit" ADD "depositRelayerFeePct" numeric`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "deposit" DROP COLUMN "depositRelayerFeePct"`);
+  }
+}

--- a/src/modules/deposit/adapter/db/queries.ts
+++ b/src/modules/deposit/adapter/db/queries.ts
@@ -18,6 +18,9 @@ export const getAvgFillTimeQuery = () => {
   return `
     select trunc(avg(extract(epoch from "filledDate" - "depositDate"))) as "avgFillTime"
     from deposit
-    where status = 'filled' and "depositDate" is not null and "filledDate" is not null;
+    where status = 'filled' and
+          "filledDate" is not null and
+          "depositDate" > NOW() - INTERVAL '30 days' and
+          "depositRelayerFeePct" / power(10, 18) >= 0.0001;
   `;
 };

--- a/src/modules/scraper/adapter/messaging/BlocksEventsConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/BlocksEventsConsumer.ts
@@ -63,7 +63,7 @@ export class BlocksEventsConsumer {
 
   private async fromFundsDepositedEventToDeposit(event: FundsDepositedEvent) {
     const { transactionHash, blockNumber } = event;
-    const { depositId, originChainId, destinationChainId, amount, originToken, depositor } = event.args;
+    const { depositId, originChainId, destinationChainId, amount, originToken, depositor, relayerFeePct } = event.args;
 
     return this.depositRepository.create({
       depositId,
@@ -77,6 +77,7 @@ export class BlocksEventsConsumer {
       fillTxs: [],
       blockNumber,
       depositorAddr: depositor,
+      depositRelayerFeePct: relayerFeePct.toString(),
     });
   }
 

--- a/src/modules/scraper/model/deposit.entity.ts
+++ b/src/modules/scraper/model/deposit.entity.ts
@@ -59,6 +59,9 @@ export class Deposit {
   @Column({ type: "decimal", default: 0 })
   realizedLpFeePct: string;
 
+  @Column({ type: "decimal" })
+  depositRelayerFeePct?: string;
+
   @Column({ type: "decimal", default: 0 })
   realizedLpFeePctCapped: string;
 


### PR DESCRIPTION
Changes

1. store the deposit event's relayer fee in the DB
2. improve the avg fill time query to include only the deposits from the past 30 days with relayer fee >= 0.0001