### PR TITLE
hotfix: fix decimals in welcome traveler completion script (prod)

### DIFF
--- a/src/modules/airdrop/services/airdrop-service.ts
+++ b/src/modules/airdrop/services/airdrop-service.ts
@@ -111,7 +111,7 @@ export class AirdropService {
         .innerJoin(Token, "token", "deposit.tokenId = token.id")
         .where("deposit.depositorAddr = :depositorAddr", { depositorAddr: checksumAddress })
         .andWhere(
-          "((token.symbol = 'USDC' and deposit.amount / token.decimals >= :usdAmount) or (token.symbol = 'WETH' and deposit.amount / token.decimals >= :wethAmount))",
+          "((token.symbol = 'USDC' and deposit.amount / power(10, token.decimals) >= :usdAmount) or (token.symbol = 'WETH' and deposit.amount / power(10, token.decimals) >= :wethAmount))",
           { usdAmount: 150, wethAmount: 0.1 },
         );
       const depositCount = await depositCountQuery.getCount();

--- a/test/airdrop.e2e-spec.ts
+++ b/test/airdrop.e2e-spec.ts
@@ -139,7 +139,7 @@ describe("GET /airdrop/rewards", () => {
         status: "filled",
         tokenAddr: token.address,
         tokenId: token.id,
-        amount: BigNumber.from(150).mul(BigNumber.from(10).mul(token.decimals)).toString(),
+        amount: BigNumber.from(150).mul(BigNumber.from(10).pow(token.decimals)).toString(),
       }),
     );
     const response = await request(app.getHttpServer())

--- a/test/airdrop.e2e-spec.ts
+++ b/test/airdrop.e2e-spec.ts
@@ -139,7 +139,7 @@ describe("GET /airdrop/rewards", () => {
         status: "filled",
         tokenAddr: token.address,
         tokenId: token.id,
-        amount: BigNumber.from(150).mul(token.decimals).toString(),
+        amount: BigNumber.from(150).mul(BigNumber.from(10).mul(token.decimals)).toString(),
       }),
     );
     const response = await request(app.getHttpServer())


### PR DESCRIPTION
Changes `token.decimals` to `power(10, token.decimals)` in `depositCountQuery`