### PR TITLE
hotfix: don't retry token details for missing deposit

### DIFF
--- a/src/modules/scraper/adapter/messaging/TokenDetailsConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/TokenDetailsConsumer.ts
@@ -22,7 +22,7 @@ export class TokenDetailsConsumer {
   private async process(job: Job<TokenDetailsQueueMessage>) {
     const { depositId } = job.data;
     const deposit = await this.depositRepository.findOne({ where: { id: depositId } });
-    if (!deposit) throw new Error("Deposit not found");
+    if (!deposit) return;
     const { sourceChainId, tokenAddr } = deposit;
     const token = await this.ethProvidersService.getCachedToken(sourceChainId, tokenAddr);
     if (!token) throw new Error("Token not found");

--- a/test/airdrop.e2e-spec.ts
+++ b/test/airdrop.e2e-spec.ts
@@ -115,6 +115,7 @@ describe("GET /airdrop/rewards", () => {
         tokenAddr: token.address,
         tokenId: token.id,
         amount: BigNumber.from(149).mul(token.decimals).toString(),
+        depositDate: new Date("2022-11-20 00:00:00"),
       }),
     );
     const response = await request(app.getHttpServer())
@@ -140,6 +141,7 @@ describe("GET /airdrop/rewards", () => {
         tokenAddr: token.address,
         tokenId: token.id,
         amount: BigNumber.from(150).mul(token.decimals).toString(),
+        depositDate: new Date("2022-11-20 00:00:00"),
       }),
     );
     const response = await request(app.getHttpServer())


### PR DESCRIPTION
If the deposit doesn't exist in the DB, disable the retry mechanism for the consumer that fetches the token details for that deposit