### PR TITLE
fix: add test for BT rewards

### DIFF
--- a/src/modules/airdrop/services/airdrop-service.ts
+++ b/src/modules/airdrop/services/airdrop-service.ts
@@ -198,7 +198,7 @@ export class AirdropService {
             .into(MerkleDistributorRecipient)
             .values({
               merkleDistributorWindowId: windowId,
-              address: recipient["account"],
+              address: ethers.utils.getAddress(recipient["account"]),
               amount: recipient["amount"],
               accountIndex: recipient["accountIndex"],
               proof: recipient["proof"],

--- a/test/airdrop/merkle-distributor.json
+++ b/test/airdrop/merkle-distributor.json
@@ -5,7 +5,7 @@
   "rewardsToDeposit": "40",
   "merkleRoot": "0x22d3a95c82f748d96d4bd698bf1177d0ce98aab22f9a8410a870544f465cb8c8",
   "recipientsWithProofs": {
-    "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3ac": {
+    "0xF2f5C73fa04406b1995e397B55c24aB1f3eA726C": {
       "metadata": {
         "amountBreakdown": {
           "communityRewards": "5",
@@ -15,7 +15,7 @@
           "referralRewards": "0"
         }
       },
-      "account": "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3ac",
+      "account": "0xF2f5C73fa04406b1995e397B55c24aB1f3eA726C",
       "amount": "10",
       "accountIndex": 0,
       "proof": ["0x939b447f774f79401f5551d9b457e92a05a9ea27505739b2aefc7490f026dcba"],


### PR DESCRIPTION
This PR adds a test to ensure that deposits after a certain date doesn't count for BT rewards `completed` flag