### PR TITLE
fix: clear HTTP logs

### DIFF
--- a/src/logging.interceptor.ts
+++ b/src/logging.interceptor.ts
@@ -19,8 +19,6 @@ export class LogsMiddleware implements NestMiddleware {
       if (statusCode >= 400) {
         return this.logger.warn(message);
       }
-
-      return this.logger.log(message);
     });
 
     next();


### PR DESCRIPTION
For each req the backend logs a message similar to `${method} ${endpoint} ${statusCode} ${statusMessage}`

This PR allows only 5xx and 4xx HTTP logs. Displaying logs on each requests make them unreadable during periods with high traffic 