### PR TITLE
feat: 💲add ACX price to deposits

### DIFF
--- a/migrations/1669984610619-Deposit.ts
+++ b/migrations/1669984610619-Deposit.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Deposit1669984610619 implements MigrationInterface {
+  name = "Deposit1669984610619";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "deposit" ADD "acxUsdPrice" numeric`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "deposit" DROP COLUMN "acxUsdPrice"`);
+  }
+}

--- a/src/modules/market-price/adapters/coingecko/index.ts
+++ b/src/modules/market-price/adapters/coingecko/index.ts
@@ -12,6 +12,7 @@ const symbolIdMap = {
   dai: "dai",
   bal: "balancer",
   usdt: "tether",
+  acx: "across-protocol",
 };
 
 @Injectable()

--- a/src/modules/scraper/adapter/messaging/DepositAcxPriceConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/DepositAcxPriceConsumer.ts
@@ -1,0 +1,39 @@
+import { OnQueueFailed, Process, Processor } from "@nestjs/bull";
+import { Logger } from "@nestjs/common";
+import { Job } from "bull";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { DateTime } from "luxon";
+import { DepositAcxPriceQueueMessage, ScraperQueue } from ".";
+import { Deposit } from "../../model/deposit.entity";
+import { MarketPriceService } from "../../../market-price/services/service";
+
+@Processor(ScraperQueue.DepositAcxPrice)
+export class DepositAcxPriceConsumer {
+  private logger = new Logger(DepositAcxPriceConsumer.name);
+
+  constructor(
+    @InjectRepository(Deposit) private depositRepository: Repository<Deposit>,
+    private marketPriceService: MarketPriceService,
+  ) {}
+
+  @Process()
+  private async process(job: Job<DepositAcxPriceQueueMessage>) {
+    const { depositId } = job.data;
+    const deposit = await this.depositRepository.findOne({ where: { id: depositId } });
+
+    if (!deposit) return;
+    if (!deposit.depositDate) throw new Error("Invalid deposit");
+
+    const previousDate = DateTime.fromISO(deposit.depositDate.toISOString()).minus({ days: 1 }).toJSDate();
+    const price = await this.marketPriceService.getCachedHistoricMarketPrice(previousDate, "acx");
+
+    if (!price) throw new Error("Price not found");
+    await this.depositRepository.update({ id: depositId }, { acxUsdPrice: price.usd });
+  }
+
+  @OnQueueFailed()
+  private onQueueFailed(job: Job, error: Error) {
+    this.logger.error(`${ScraperQueue.DepositAcxPrice} ${JSON.stringify(job.data)} failed: ${error}`);
+  }
+}

--- a/src/modules/scraper/adapter/messaging/index.ts
+++ b/src/modules/scraper/adapter/messaging/index.ts
@@ -7,6 +7,7 @@ export enum ScraperQueue {
   TokenPrice = "TokenPrice",
   DepositFilledDate = "DepositFilledDate",
   MerkleDistributorBlocksEvents = "MerkleDistributorBlocksEvents",
+  DepositAcxPrice = "DepositAcxPrice",
 }
 
 export type BlocksEventsQueueMessage = {
@@ -48,5 +49,9 @@ export type TokenPriceQueueMessage = {
 };
 
 export type DepositFilledDateQueueMessage = {
+  depositId: number;
+};
+
+export type DepositAcxPriceQueueMessage = {
   depositId: number;
 };

--- a/src/modules/scraper/entry-point/http/controller.ts
+++ b/src/modules/scraper/entry-point/http/controller.ts
@@ -12,6 +12,7 @@ import {
   ScraperQueue,
   TokenPriceQueueMessage,
   TokenDetailsQueueMessage,
+  DepositAcxPriceQueueMessage,
 } from "../../adapter/messaging";
 import { ScraperService } from "../../service";
 import { ScraperQueuesService } from "../../service/ScraperQueuesService";
@@ -21,6 +22,7 @@ import {
   ProcessPricesBody,
   SubmitDepositFilledDateBody,
   ProcessBlockNumberBody,
+  SubmitDepositAcxPriceBody,
 } from "./dto";
 
 @Controller()
@@ -125,6 +127,21 @@ export class ScraperController {
 
     for (let depositId = fromDepositId; depositId <= toDepositId; depositId++) {
       await this.scraperQueuesService.publishMessage<DepositFilledDateQueueMessage>(ScraperQueue.DepositFilledDate, {
+        depositId,
+      });
+    }
+  }
+
+  @Post("scraper/deposit-acx-price")
+  @ApiTags("scraper")
+  @Roles(Role.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  async submitDepositAcxPriceJob(@Body() body: SubmitDepositAcxPriceBody) {
+    const { fromDepositId, toDepositId } = body;
+
+    for (let depositId = fromDepositId; depositId <= toDepositId; depositId++) {
+      await this.scraperQueuesService.publishMessage<DepositAcxPriceQueueMessage>(ScraperQueue.DepositAcxPrice, {
         depositId,
       });
     }

--- a/src/modules/scraper/entry-point/http/dto.ts
+++ b/src/modules/scraper/entry-point/http/dto.ts
@@ -45,6 +45,16 @@ export class SubmitDepositFilledDateBody {
   toDepositId: number;
 }
 
+export class SubmitDepositAcxPriceBody {
+  @IsInt()
+  @ApiProperty({ example: 1 })
+  fromDepositId: number;
+
+  @IsInt()
+  @ApiProperty({ example: 2 })
+  toDepositId: number;
+}
+
 export class ProcessBlockNumberBody {
   @IsInt()
   @ApiProperty({ example: 1 })

--- a/src/modules/scraper/model/deposit.entity.ts
+++ b/src/modules/scraper/model/deposit.entity.ts
@@ -103,6 +103,9 @@ export class Deposit {
   @Column({ nullable: true })
   rewardsWindowIndex?: number;
 
+  @Column({ type: "decimal", nullable: true })
+  acxUsdPrice?: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/modules/scraper/module.ts
+++ b/src/modules/scraper/module.ts
@@ -26,6 +26,7 @@ import { ProcessedBlock } from "./model/ProcessedBlock.entity";
 import { MerkleDistributorProcessedBlock } from "./model/MerkleDistributorProcessedBlock.entity";
 import { ScraperService } from "./service";
 import { ScraperQueuesService } from "./service/ScraperQueuesService";
+import { DepositAcxPriceConsumer } from "./adapter/messaging/DepositAcxPriceConsumer";
 
 @Module({
   providers: [
@@ -39,6 +40,7 @@ import { ScraperQueuesService } from "./service/ScraperQueuesService";
     DepositReferralConsumer,
     TokenPriceConsumer,
     DepositFilledDateConsumer,
+    DepositAcxPriceConsumer,
     DepositFixture,
     ClaimFixture,
   ],
@@ -66,6 +68,9 @@ import { ScraperQueuesService } from "./service/ScraperQueuesService";
     }),
     BullModule.registerQueue({
       name: ScraperQueue.DepositReferral,
+    }),
+    BullModule.registerQueue({
+      name: ScraperQueue.DepositAcxPrice,
     }),
     BullModule.registerQueue({
       name: ScraperQueue.FillEvents,

--- a/src/modules/scraper/service/ScraperQueuesService.ts
+++ b/src/modules/scraper/service/ScraperQueuesService.ts
@@ -16,6 +16,7 @@ export class ScraperQueuesService {
     @InjectQueue(ScraperQueue.DepositReferral) private depositReferralQueue: Queue,
     @InjectQueue(ScraperQueue.TokenPrice) private tokenPriceQueue: Queue,
     @InjectQueue(ScraperQueue.DepositFilledDate) private depositFilledDateQueue: Queue,
+    @InjectQueue(ScraperQueue.DepositAcxPrice) private depositAcxPriceQueue: Queue,
   ) {
     setInterval(() => {
       this.blocksEventsQueue
@@ -42,6 +43,9 @@ export class ScraperQueuesService {
       this.depositFilledDateQueue
         .getJobCounts()
         .then((data) => this.logger.log(`${ScraperQueue.DepositFilledDate} ${JSON.stringify(data)}`));
+      this.depositAcxPriceQueue
+        .getJobCounts()
+        .then((data) => this.logger.log(`${ScraperQueue.DepositAcxPrice} ${JSON.stringify(data)}`));
     }, 1000 * 60);
   }
 
@@ -62,6 +66,8 @@ export class ScraperQueuesService {
       await this.depositFilledDateQueue.add(message);
     } else if (queue === ScraperQueue.MerkleDistributorBlocksEvents) {
       await this.merkleDistributorBlocksEventsQueue.add(message);
+    } else if (queue === ScraperQueue.DepositAcxPrice) {
+      await this.depositAcxPriceQueue.add(message);
     }
   }
 
@@ -82,6 +88,8 @@ export class ScraperQueuesService {
       await this.depositFilledDateQueue.addBulk(messages.map((m) => ({ data: m })));
     } else if (queue === ScraperQueue.MerkleDistributorBlocksEvents) {
       await this.merkleDistributorBlocksEventsQueue.addBulk(messages.map((m) => ({ data: m })));
+    } else if (queue === ScraperQueue.DepositAcxPrice) {
+      await this.depositAcxPriceQueue.addBulk(messages.map((m) => ({ data: m })));
     }
   }
 }


### PR DESCRIPTION
#### This PR that adds a new `acxUsdPrice` column to the deposit table that is needed in order to integrate the ACX price into the referral rewards. This has been achieved with the following changes:

- [add a new column to the `deposit` table that stores the ACX price at deposit time](https://github.com/across-protocol/scraper-api/pull/167/files#diff-c383b9143f9470ba7049fb7b2ebccf78fabf8ce0c860bc23468a19d5bfc11c42)
- [modify the MarketPrice service so that if the symbol is ACX and the requested date is before the token launch date, then return a hardcoded 0.1$ price](https://github.com/across-protocol/scraper-api/pull/167/files#diff-97817ef88b82b51f1edaad6e49f344c57d4b18b5fd086792981b5cc3bcd0732cR15-R32)
- [implement the `DepositAcxPriceConsumer` consumer which receives a deposit id and populates the `acxUsdPrice` column of the deposit table](https://github.com/across-protocol/scraper-api/pull/167/files#diff-de778566aa857d13a2988148a1c2e617fd3bfb0c99d2b453a8bc9a8e5e2604e6). The messages to this queue will be published after the token's price has been fetched for the deposit by the `TokenPriceConsumer` [here](https://github.com/across-protocol/scraper-api/pull/167/files#diff-0f46957f0bd6e43148e6e4f9eaa238811925a6f45969836e273b28a50d7a77b6R37)
- [add an endpoint which allows to publish manually messages to `DepositAcxPriceConsumer`](https://github.com/across-protocol/scraper-api/pull/167/files#diff-6584665fe6b6350a2fbd5484d734bd1ff0cf61d68dab6699a06c4f8e16fa95d4R135-R148)