### PR TITLE
chore(license): update license

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.1",
   "description": "Scraper API",
-  "license": "MIT",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
**Scope**
This change updates the `package.json` license to GPL-3.0. 

**Motivation**
The original SPDX-identifier for the GNU Affero GPL 3.0 license (`AGPL-3.0`) has been deprecated. 

![image](https://user-images.githubusercontent.com/96435344/206530552-bf86d219-1ace-4a56-b6b1-26ca27f934bc.png)

The more current SPDX identifier for the Affero GPL 3.0 is `AGPL-3.0-only`