### PR TITLE
feat: use `suggestedRelayerFeePct` in `GET /deposits` endpoint

### DIFF
--- a/migrations/1670942459408-Deposit.ts
+++ b/migrations/1670942459408-Deposit.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Deposit1670942459408 implements MigrationInterface {
+  name = "Deposit1670942459408";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "deposit" ALTER COLUMN "suggestedRelayerFeePct" SET NOT NULL`);
+    await queryRunner.query(
+      `ALTER TABLE "deposit" ALTER COLUMN "suggestedRelayerFeePct" SET DEFAULT '100000000000000'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "deposit" ALTER COLUMN "suggestedRelayerFeePct" DROP DEFAULT`);
+    await queryRunner.query(`ALTER TABLE "deposit" ALTER COLUMN "suggestedRelayerFeePct" DROP NOT NULL`);
+  }
+}

--- a/src/modules/configuration/index.ts
+++ b/src/modules/configuration/index.ts
@@ -100,6 +100,7 @@ export const configValues = () => ({
   suggestedFees: {
     apiUrl: process.env.SUGGESTED_FEES_API_URL || "https://across.to/api/suggested-fees",
     fallbackThresholdHours: Number(process.env.SUGGESTED_FEES_FALLBACK_THRESHOLD_HOURS || "4"),
+    deviationBufferMultiplier: Number(process.env.SUGGESTED_FEES_DEVIATION_BUFFER_MULTIPLIER || "1.25"),
   },
 });
 

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -5,13 +5,14 @@ import { Repository } from "typeorm";
 import { Cache } from "cache-manager";
 import { Deposit } from "../scraper/model/deposit.entity";
 import { getAvgFillTimeQuery, getTotalDepositsQuery, getTotalVolumeQuery } from "./adapter/db/queries";
+import { AppConfig } from "../configuration/configuration.service";
 
 export const DEPOSITS_STATS_CACHE_KEY = "deposits:stats";
-export const SUGGESTED_FEES_DEVIATION_BUFFER_MULTIPLIER = 1.1;
 
 @Injectable()
 export class DepositService {
   constructor(
+    private appConfig: AppConfig,
     @InjectRepository(Deposit) private depositRepository: Repository<Deposit>,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
@@ -55,7 +56,7 @@ export class DepositService {
         .where("d.status = :status", { status })
         .andWhere("d.depositDate > NOW() - INTERVAL '1 days'")
         .andWhere(`d.depositRelayerFeePct * :multiplier >= d.suggestedRelayerFeePct`, {
-          multiplier: SUGGESTED_FEES_DEVIATION_BUFFER_MULTIPLIER,
+          multiplier: this.appConfig.values.suggestedFees.deviationBufferMultiplier,
         })
         .orderBy("d.depositDate", "DESC")
         .take(limit)

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -54,9 +54,9 @@ export class DepositService {
         .createQueryBuilder("d")
         .where("d.status = :status", { status })
         .andWhere("d.depositDate > NOW() - INTERVAL '1 days'")
-        .andWhere(
-          `d.depositRelayerFeePct / power(10, 18) * ${SUGGESTED_FEES_DEVIATION_BUFFER_MULTIPLIER} >= d.suggestedRelayerFeePct / power(10, 18)`,
-        )
+        .andWhere(`d.depositRelayerFeePct * :multiplier >= d.suggestedRelayerFeePct`, {
+          multiplier: SUGGESTED_FEES_DEVIATION_BUFFER_MULTIPLIER,
+        })
         .orderBy("d.depositDate", "DESC")
         .take(limit)
         .skip(offset)
@@ -89,11 +89,15 @@ export class DepositService {
  */
 export function formatDeposit(deposit: Deposit) {
   return {
+    depositId: deposit.depositId,
     depositTime: Math.round(DateTime.fromISO(deposit.depositDate.toISOString()).toSeconds()),
+    status: deposit.status,
+    filled: deposit.filled,
     sourceChainId: deposit.sourceChainId,
     destinationChainId: deposit.destinationChainId,
     assetAddr: deposit.tokenAddr,
+    amount: deposit.amount,
+    depositTxHash: deposit.depositTxHash,
     fillTxs: deposit.fillTxs.map(({ hash }) => hash),
-    ...deposit,
   };
 }

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -99,5 +99,6 @@ export function formatDeposit(deposit: Deposit) {
     amount: deposit.amount,
     depositTxHash: deposit.depositTxHash,
     fillTxs: deposit.fillTxs.map(({ hash }) => hash),
+    depositRelayerFeePct: deposit.depositRelayerFeePct,
   };
 }

--- a/src/modules/scraper/model/deposit.entity.ts
+++ b/src/modules/scraper/model/deposit.entity.ts
@@ -62,8 +62,8 @@ export class Deposit {
   @Column({ type: "decimal" })
   depositRelayerFeePct?: string;
 
-  @Column({ type: "decimal", nullable: true })
-  suggestedRelayerFeePct?: string;
+  @Column({ type: "decimal", default: 100000000000000 }) // default 1bp = 0.01%
+  suggestedRelayerFeePct: string;
 
   @Column({ type: "decimal", default: 0 })
   realizedLpFeePctCapped: string;


### PR DESCRIPTION
Closes ACX-467

Add migration to use 1bp as the default value for `suggestedRelayerFeePct` because it can be updated by the consumer if appropriate. This also adapts the `where` clause to use the new column for pending deposits displayed in the "All Transactions" table.