### PR TITLE
fix: fix grouping deposits by claimed window

### DIFF
--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -298,6 +298,7 @@ export class ReferralService {
     const claims = await entityManager
       .createQueryBuilder(Claim, "c")
       .where("c.account = :account", { account: referralAddress })
+      .andWhere("c.windowIndex > 0")
       .orderBy("c.claimedAt", "ASC")
       .getMany();
     const deposits = await entityManager


### PR DESCRIPTION
Consider only window > 0 when grouping deposits by claimed window for computing referral rewards