### PR TITLE
fix: fix referral address extraction

### DIFF
--- a/src/modules/referral/services/service.spec.ts
+++ b/src/modules/referral/services/service.spec.ts
@@ -8,10 +8,8 @@ describe("ReferralService", () => {
     const moduleRef = await Test.createTestingModule({
       providers: [ReferralService],
     })
-      .useMocker((token) => {
-        if (token === "DepositRepository") {
-          return {};
-        }
+      .useMocker(() => {
+        return {};
       })
       .compile();
 
@@ -42,6 +40,13 @@ describe("ReferralService", () => {
   it("should extract referral address if delimiter is not found", () => {
     const address = service.extractReferralAddressUsingDelimiter(
       "0x492289780000000000000000000000009a8f92a830a5cb89a3816e3d267cb7791c16b04d000000000000000000000000d693ec944a85eeca4247ec1c3b130dca9b0c3b220000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000000000000000000890000000000000000000000000000000000000000000000000004119f446d1d2f0000000000000000000000000000000000000000000000000000000062c836e59a8f92a830a5cb89a3816e3d267cb7791c16b04d",
+    );
+    expect(address).toEqual(undefined);
+  });
+
+  it("should not extract referral address if calldata too short", () => {
+    const address = service.extractReferralAddressUsingDelimiter(
+      "0xb1a8f7c700000000000000000000000000000000000000000000000000000000000000ca00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000022000100000000000000000000000000000000000000000000000000000000000c3500000000000000000000000000000000000000000000000000000000000000",
     );
     expect(address).toEqual(undefined);
   });

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -171,18 +171,29 @@ export class ReferralService {
   }
 
   public subtractFunctionArgsFromCallData(data: string) {
-    const coder = new ethers.utils.AbiCoder();
-    // strip hex method identifier
-    const dataNoMethod = ethers.utils.hexDataSlice(data, 4);
-    // keep method hex identifier
-    const methodHex = data.replace(dataNoMethod.replace("0x", ""), "");
-    const decodedData = coder.decode(
-      ["address", "address", "uint256", "uint256", "uint64", "uint32"],
-      ethers.utils.hexDataSlice(data, 4),
-    );
-    const encoded = coder.encode(["address", "address", "uint256", "uint256", "uint64", "uint32"], decodedData);
-    const fullEncoded = methodHex + encoded.replace("0x", "");
-    return data.replace(fullEncoded, "");
+    try {
+      const coder = new ethers.utils.AbiCoder();
+      // strip hex method identifier
+      const dataNoMethod = ethers.utils.hexDataSlice(data, 4);
+      // keep method hex identifier
+      const methodHex = data.replace(dataNoMethod.replace("0x", ""), "");
+      const decodedData = coder.decode(
+        ["address", "address", "uint256", "uint256", "uint64", "uint32"],
+        ethers.utils.hexDataSlice(data, 4),
+      );
+      const encoded = coder.encode(["address", "address", "uint256", "uint256", "uint64", "uint32"], decodedData);
+      const fullEncoded = methodHex + encoded.replace("0x", "");
+      return data.replace(fullEncoded, "");
+    } catch (error) {
+      console.log(JSON.stringify(error, undefined, 2));
+      if (error.reason === "value out of range" && error.code === "INVALID_ARGUMENT") {
+        return "";
+      }
+      if (error.reason === "data out-of-bounds" && error.code === "BUFFER_OVERRUN") {
+        return "";
+      }
+      throw error;
+    }
   }
 
   public extractReferralAddressUsingDelimiter(data: string) {

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -189,7 +189,7 @@ export class ReferralService {
       const fullEncoded = methodHex + encoded.replace("0x", "");
       return data.replace(fullEncoded, "");
     } catch (error) {
-      if (error.code === "BUFFER_OVERRUN") {
+      if (error?.code === "BUFFER_OVERRUN") {
         // return empty string if the calldata's length in bytes is less than the length of the deposit function signature
         return "";
       } else {

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -175,33 +175,14 @@ export class ReferralService {
    * @param data
    */
   public subtractFunctionArgsFromCallData(data: string) {
-    try {
-      const coder = new ethers.utils.AbiCoder();
-      // strip hex method identifier
-      const dataNoMethod = ethers.utils.hexDataSlice(data, 4);
-      // keep method hex identifier
-      const methodHex = data.replace(dataNoMethod.replace("0x", ""), "");
-      const decodedData = coder.decode(
-        ["address", "address", "uint256", "uint256", "uint64", "uint32"],
-        ethers.utils.hexDataSlice(data, 4),
-      );
-      const encoded = coder.encode(["address", "address", "uint256", "uint256", "uint64", "uint32"], decodedData);
-      const fullEncoded = methodHex + encoded.replace("0x", "");
-      return data.replace(fullEncoded, "");
-    } catch (error) {
-      if (error?.code === "BUFFER_OVERRUN") {
-        // return empty string if the calldata's length in bytes is less than the length of the deposit function signature
-        return "";
-      } else {
-        this.logger.error(JSON.stringify(error, undefined, 2));
-        throw error;
-      }
-    }
+    // the length of the string including the method identifier and
+    // the deposit function args ["address", "address", "uint256", "uint256", "uint64", "uint32"]
+    const methodIdAndArgsLength = 395;
+    return data.slice(methodIdAndArgsLength - 1);
   }
 
   public extractReferralAddressUsingDelimiter(data: string) {
     const referralData = this.subtractFunctionArgsFromCallData(data);
-
     if (referralData.indexOf(REFERRAL_ADDRESS_DELIMITER) !== -1) {
       const addressIndex = referralData.indexOf(REFERRAL_ADDRESS_DELIMITER) + REFERRAL_ADDRESS_DELIMITER.length;
       const potentialAddress = referralData.slice(addressIndex, addressIndex + 40);

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -183,6 +183,7 @@ export class ReferralService {
 
   public extractReferralAddressUsingDelimiter(data: string) {
     const referralData = this.subtractFunctionArgsFromCallData(data);
+
     if (referralData.indexOf(REFERRAL_ADDRESS_DELIMITER) !== -1) {
       const addressIndex = referralData.indexOf(REFERRAL_ADDRESS_DELIMITER) + REFERRAL_ADDRESS_DELIMITER.length;
       const potentialAddress = referralData.slice(addressIndex, addressIndex + 40);

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -171,33 +171,28 @@ export class ReferralService {
   }
 
   public subtractFunctionArgsFromCallData(data: string) {
-    try {
-      const coder = new ethers.utils.AbiCoder();
-      // strip hex method identifier
-      const dataNoMethod = ethers.utils.hexDataSlice(data, 4);
-      // keep method hex identifier
-      const methodHex = data.replace(dataNoMethod.replace("0x", ""), "");
-      const decodedData = coder.decode(
-        ["address", "address", "uint256", "uint256", "uint64", "uint32"],
-        ethers.utils.hexDataSlice(data, 4),
-      );
-      const encoded = coder.encode(["address", "address", "uint256", "uint256", "uint64", "uint32"], decodedData);
-      const fullEncoded = methodHex + encoded.replace("0x", "");
-      return data.replace(fullEncoded, "");
-    } catch (error) {
-      console.log(JSON.stringify(error, undefined, 2));
-      if (error.reason === "value out of range" && error.code === "INVALID_ARGUMENT") {
-        return "";
-      }
-      if (error.reason === "data out-of-bounds" && error.code === "BUFFER_OVERRUN") {
-        return "";
-      }
-      throw error;
-    }
+    const coder = new ethers.utils.AbiCoder();
+    // strip hex method identifier
+    const dataNoMethod = ethers.utils.hexDataSlice(data, 4);
+    // keep method hex identifier
+    const methodHex = data.replace(dataNoMethod.replace("0x", ""), "");
+    const decodedData = coder.decode(
+      ["address", "address", "uint256", "uint256", "uint64", "uint32"],
+      ethers.utils.hexDataSlice(data, 4),
+    );
+    const encoded = coder.encode(["address", "address", "uint256", "uint256", "uint64", "uint32"], decodedData);
+    const fullEncoded = methodHex + encoded.replace("0x", "");
+    return data.replace(fullEncoded, "");
   }
 
   public extractReferralAddressUsingDelimiter(data: string) {
-    const referralData = this.subtractFunctionArgsFromCallData(data);
+    let referralData = "";
+
+    try {
+      referralData = this.subtractFunctionArgsFromCallData(data);
+    } catch (error) {
+      return undefined;
+    }
 
     if (referralData.indexOf(REFERRAL_ADDRESS_DELIMITER) !== -1) {
       const addressIndex = referralData.indexOf(REFERRAL_ADDRESS_DELIMITER) + REFERRAL_ADDRESS_DELIMITER.length;


### PR DESCRIPTION
`subtractFunctionArgsFromCallData` function removes the function arguments from the calldata, returning only the arbitrary data that can be attached to a transaction. IF the calldata's length in bytes is less than the length of the deposit function signature `["address", "address", "uint256", "uint256", "uint64", "uint32"]` , then return empty string.