### PR TITLE
refactor: rename ampli events and prop adjustments

### DIFF
--- a/src/modules/ampli/index.ts
+++ b/src/modules/ampli/index.ts
@@ -7,7 +7,7 @@
  * To update run 'ampli pull scraper'
  *
  * Required dependencies: @amplitude/analytics-node@^0.5.0
- * Tracking Plan Version: 30
+ * Tracking Plan Version: 32
  * Build: 1.0.0
  * Runtime: node.js:typescript-ampli-v2
  *
@@ -37,10 +37,10 @@ export const ApiKey: Record<Environment, string> = {
  */
 export const DefaultConfiguration: NodeOptions = {
   plan: {
-    version: "30",
+    version: "32",
     branch: "main",
     source: "scraper",
-    versionId: "0b21d764-e05a-48ac-9da6-95b3efc901dd",
+    versionId: "e6298d8b-58e2-45e6-a09d-0f244c0489ab",
   },
   ...{
     ingestionMetadata: {
@@ -117,7 +117,7 @@ export interface IdentifyProperties {
   walletType?: string;
 }
 
-export interface TransferTransactionConfirmedProperties {
+export interface FillTransactionCompletedProperties {
   /**
    * Capital fee percent, in decimals
    */
@@ -130,8 +130,11 @@ export interface TransferTransactionConfirmedProperties {
    * Capital fee in USD
    */
   capitalFeeTotalUsd: string;
+  depositCompleteTimestamp: string;
   fillAmount: string;
   fillAmountUsd: string;
+  fillCompleteTimestamp: string;
+  fillTime: string;
   /**
    * From amount in the bridge token, in decimals
    */
@@ -141,7 +144,7 @@ export interface TransferTransactionConfirmedProperties {
    */
   fromAmountUsd: string;
   /**
-   * From chain id
+   * Id of the fromChain
    */
   fromChainId: string;
   /**
@@ -226,10 +229,6 @@ export interface TransferTransactionConfirmedProperties {
    */
   succeeded: boolean;
   /**
-   * Duration in milliseconds between TransferSigned event to the TransferTransactionCompleted event
-   */
-  timeFromTransferSignedToTransferCompleteInMilliseconds: string;
-  /**
    * To amount of bridge token, in decimals
    */
   toAmount: string;
@@ -268,14 +267,9 @@ export interface TransferTransactionConfirmedProperties {
    */
   toTokenAddress: string;
   /**
-   * Resulting transaction hash of transaction, null if "result" if TransferTransactionCompleted = failed
+   * Resulting transaction hash of transaction, null if "result" if SwapSigned event = failed
    */
   transactionHash: string;
-  /**
-   * Timestamp transfer completed
-   */
-  transferCompleteTimestamp: string;
-  transferQuoteBlockNumber: string;
 }
 
 export class Identify implements BaseEvent {
@@ -286,10 +280,10 @@ export class Identify implements BaseEvent {
   }
 }
 
-export class TransferTransactionConfirmed implements BaseEvent {
-  event_type = "TransferTransactionConfirmed";
+export class FillTransactionCompleted implements BaseEvent {
+  event_type = "FillTransactionCompleted";
 
-  constructor(public event_properties: TransferTransactionConfirmedProperties) {
+  constructor(public event_properties: FillTransactionCompletedProperties) {
     this.event_properties = event_properties;
   }
 }
@@ -411,24 +405,22 @@ export class Ampli {
   }
 
   /**
-   * TransferTransactionConfirmed
+   * FillTransactionCompleted
    *
-   * [View in Tracking Plan](https://data.amplitude.com/risklabs/Risk%20Labs/events/main/latest/TransferTransactionConfirmed)
+   * [View in Tracking Plan](https://data.amplitude.com/risklabs/Risk%20Labs/events/main/latest/FillTransactionCompleted)
    *
-   * On-chain transfer completed
-   *
-   * Owner: James Morris
+   * Owner: Dong-Ha Kim
    *
    * @param userId The user's ID.
    * @param properties The event's properties (e.g. capitalFeePct)
    * @param options Amplitude event options.
    */
-  transferTransactionConfirmed(
+  fillTransactionCompleted(
     userId: string | undefined,
-    properties: TransferTransactionConfirmedProperties,
+    properties: FillTransactionCompletedProperties,
     options?: EventOptions,
   ) {
-    return this.track(userId, new TransferTransactionConfirmed(properties), options);
+    return this.track(userId, new FillTransactionCompleted(properties), options);
   }
 }
 

--- a/src/modules/scraper/adapter/amplitude/track-service.ts
+++ b/src/modules/scraper/adapter/amplitude/track-service.ts
@@ -1,7 +1,7 @@
 import { HttpService } from "@nestjs/axios";
 import { Injectable } from "@nestjs/common";
 
-import { EventOptions, TransferTransactionConfirmedProperties, ampli } from "../../../ampli";
+import { EventOptions, FillTransactionCompletedProperties, ampli } from "../../../ampli";
 import { AppConfig } from "../../../configuration/configuration.service";
 
 @Injectable()
@@ -22,9 +22,9 @@ export class TrackService {
 
   public async trackDepositFilledEvent(
     userId: string,
-    eventProperties: TransferTransactionConfirmedProperties,
+    eventProperties: FillTransactionCompletedProperties,
     eventOptions?: EventOptions,
   ) {
-    return ampli.transferTransactionConfirmed(userId, eventProperties, eventOptions);
+    return ampli.fillTransactionCompleted(userId, eventProperties, eventOptions);
   }
 }

--- a/src/modules/scraper/adapter/messaging/TrackFillEventConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/TrackFillEventConsumer.ts
@@ -97,8 +97,11 @@ export class TrackFillEventConsumer {
       capitalFeePct,
       capitalFeeTotal: new BigNumber(capitalFeePct).dividedBy(100).multipliedBy(fromAmounts.formattedAmount).toFixed(),
       capitalFeeTotalUsd: capitalFeeUsd,
+      depositCompleteTimestamp: String(DateTime.fromJSDate(deposit.depositDate).toMillis()),
       fillAmount: fillAmounts.formattedAmount,
       fillAmountUsd: fillAmounts.formattedAmountUsd,
+      fillCompleteTimestamp: String(DateTime.fromISO(fillTx.date).toMillis()),
+      fillTime: String(DateTime.fromISO(fillTx.date).diff(DateTime.fromJSDate(deposit.depositDate)).as("milliseconds")),
       fromAmount: fromAmounts.formattedAmount,
       fromAmountUsd: fromAmounts.formattedAmountUsd,
       fromChainId: String(deposit.sourceChainId),
@@ -109,7 +112,7 @@ export class TrackFillEventConsumer {
       lpFeeTotal: formattedLpFeeValues.total,
       lpFeeTotalUsd: formattedLpFeeValues.totalUsd,
       NetworkFeeNative: fee,
-      NetworkFeeNativeToken: destinationChainInfo.nativeSymbol,
+      NetworkFeeNativeToken: destinationChainInfo.nativeSymbol.toUpperCase(),
       NetworkFeeUsd: feeUsd,
       recipient: deposit.recipientAddr,
       referralProgramAddress: deposit.referralAddress || "-",
@@ -123,9 +126,6 @@ export class TrackFillEventConsumer {
       routeChainNameFromTo: `${sourceChainInfo.name}-${destinationChainInfo.name}`,
       sender: deposit.depositorAddr,
       succeeded: true,
-      timeFromTransferSignedToTransferCompleteInMilliseconds: String(
-        DateTime.fromISO(fillTx.date).diff(DateTime.fromJSDate(deposit.depositDate)).as("milliseconds"),
-      ),
       toAmount: new BigNumber(fromAmounts.formattedAmount).minus(formattedBridgeFeeValues.total).toFixed(),
       toAmountUsd: new BigNumber(fromAmounts.formattedAmountUsd)
         .minus(formattedBridgeFeeValues.totalUsd)
@@ -133,7 +133,7 @@ export class TrackFillEventConsumer {
         .toFixed(),
       toChainId: String(deposit.destinationChainId),
       toChainName: destinationChainInfo.name,
-      tokenSymbol: deposit.token.symbol,
+      tokenSymbol: deposit.token.symbol.toUpperCase(),
       totalBridgeFee: formattedBridgeFeeValues.total,
       totalBridgeFeePct: formattedBridgeFeeValues.pct,
       totalBridgeFeeUsd: formattedBridgeFeeValues.totalUsd,
@@ -143,8 +143,6 @@ export class TrackFillEventConsumer {
       // so we default to `0x0000000000000000000000000000000000000000`
       toTokenAddress: utils.getAddress(destinationToken || constants.AddressZero),
       transactionHash: fillTx.hash,
-      transferCompleteTimestamp: String(DateTime.fromISO(fillTx.date).toMillis()),
-      transferQuoteBlockNumber: String(fillTxBlockNumber),
     });
   }
 


### PR DESCRIPTION
Closes ACX-569

@amateima my approach for later merging only the amplitude commits into `master` without the run mode changes is to use [cherry-pick](https://git-scm.com/docs/git-cherry-pick), roughly something like
```bash
git checkout master
git checkout -b amplitude-prod-update

# cherry pick relevant commits and place on top of new branch
git cherry-pick 12e211e331c010022960ca1a497f71bf8bddf86b # https://github.com/across-protocol/scraper-api/commit/12e211e331c010022960ca1a497f71bf8bddf86b
git cherry-pick 8760bd761566dd02425b3a20327a1815760c6886 # https://github.com/across-protocol/scraper-api/commit/8760bd761566dd02425b3a20327a1815760c6886
git cherry-pick <COMMIT_HASH_OF_THIS_PR_ON_STAGE>

# push upstream and create PR directly to master
git push -u origin amplitude-prod-update
```