### PR TITLE
fix: don't retry consumer if deposit doesn't exist

### DIFF
--- a/src/modules/scraper/adapter/messaging/BlockNumberConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/BlockNumberConsumer.ts
@@ -28,7 +28,7 @@ export class BlockNumberConsumer {
   private async process(job: Job<BlockNumberQueueMessage>) {
     const { depositId } = job.data;
     const deposit = await this.depositRepository.findOne({ where: { id: depositId } });
-    if (!deposit) throw new Error("Deposit not found");
+    if (!deposit) return;
     const block = await this.providers.getCachedBlock(deposit.sourceChainId, deposit.blockNumber);
     await this.depositRepository.update({ id: deposit.id }, { depositDate: block.date });
     await this.scraperQueuesService.publishMessage<TokenDetailsQueueMessage>(ScraperQueue.TokenDetails, {


### PR DESCRIPTION
`BlockNumberConsumer` is a consumer attached to `BlockNumber` queue. It receives a deposit id and computes the deposit time based on the block number of the deposit. Currently, if the deposit doesn't exist in the DB (incorrect id), the job is retried infinitely. This can happen only if messages are published manually on this queue.