### PR TITLE
feat: serve merkle distributor recipients for etl tasks

### DIFF
--- a/src/modules/airdrop/entry-points/http/controller.ts
+++ b/src/modules/airdrop/entry-points/http/controller.ts
@@ -26,11 +26,11 @@ import {
   GetMerkleDistributorProofsQuery,
 } from "./dto";
 
-@Controller()
+@Controller("airdrop")
 export class AirdropController {
   constructor(private airdropService: AirdropService) {}
 
-  @Get("airdrop/rewards")
+  @Get("rewards")
   @ApiResponse({ type: GetAirdropRewardsResponse })
   @ApiTags("airdrop")
   @UseGuards(OptionalJwtAuthGuard)
@@ -38,13 +38,13 @@ export class AirdropController {
     return this.airdropService.getRewards(query.address, req.user.id);
   }
 
-  @Patch("airdrop/rewards/wallet-rewards")
+  @Patch("rewards/wallet-rewards")
   @ApiTags("airdrop")
   editWalletRewards(@Body() body: EditWalletRewardsBody) {
     return this.airdropService.editWalletRewards(body);
   }
 
-  @Get("airdrop/welcome-traveller-eligible")
+  @Get("welcome-traveller-eligible")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiTags("airdrop")
@@ -53,7 +53,7 @@ export class AirdropController {
     return this.airdropService.getWelcomeTravellerEligibleWallets();
   }
 
-  @Get("airdrop/community-rewards-eligible")
+  @Get("community-rewards-eligible")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiTags("airdrop")
@@ -62,7 +62,7 @@ export class AirdropController {
     return this.airdropService.getCommunityRewardsEligibleWallets();
   }
 
-  @Post("airdrop/upload/rewards")
+  @Post("upload/rewards")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @UseInterceptors(
@@ -88,7 +88,7 @@ export class AirdropController {
     });
   }
 
-  @Post("airdrop/upload/merkle-distributor-recipients")
+  @Post("upload/merkle-distributor-recipients")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @UseInterceptors(
@@ -103,20 +103,20 @@ export class AirdropController {
     return this.airdropService.processMerkleDistributorRecipientsFile(file);
   }
 
-  @Get("airdrop/merkle-distributor-proof")
+  @Get("merkle-distributor-proof")
   @ApiTags("airdrop")
   getMerkleDistributorProof(@Query() query: GetMerkleDistributorProofQuery) {
     const includeDiscord = query.includeDiscord === "true";
     return this.airdropService.getMerkleDistributorProof(query.address, query.windowIndex, includeDiscord);
   }
 
-  @Get("airdrop/merkle-distributor-proofs")
+  @Get("merkle-distributor-proofs")
   @ApiTags("airdrop")
   getMerkleDistributorProofs(@Query() query: GetMerkleDistributorProofsQuery) {
     return this.airdropService.getMerkleDistributorProofs(query.address, query.startWindowIndex);
   }
 
-  @Get("airdrop/etl/merkle-distributor-recipients")
+  @Get("etl/merkle-distributor-recipients")
   @ApiTags("etl")
   getEtlMerkleDistributorRecipients(@Query() query: GetEtlMerkleDistributorRecipientsQuery) {
     return this.airdropService.getEtlMerkleDistributorRecipients(query);

--- a/src/modules/airdrop/entry-points/http/controller.ts
+++ b/src/modules/airdrop/entry-points/http/controller.ts
@@ -21,15 +21,16 @@ import {
   EditWalletRewardsBody,
   GetAirdropRewardsQuery,
   GetAirdropRewardsResponse,
+  GetEtlMerkleDistributorRecipientsQuery,
   GetMerkleDistributorProofQuery,
   GetMerkleDistributorProofsQuery,
 } from "./dto";
 
-@Controller("airdrop")
+@Controller()
 export class AirdropController {
   constructor(private airdropService: AirdropService) {}
 
-  @Get("rewards")
+  @Get("airdrop/rewards")
   @ApiResponse({ type: GetAirdropRewardsResponse })
   @ApiTags("airdrop")
   @UseGuards(OptionalJwtAuthGuard)
@@ -37,13 +38,13 @@ export class AirdropController {
     return this.airdropService.getRewards(query.address, req.user.id);
   }
 
-  @Patch("rewards/wallet-rewards")
+  @Patch("airdrop/rewards/wallet-rewards")
   @ApiTags("airdrop")
   editWalletRewards(@Body() body: EditWalletRewardsBody) {
     return this.airdropService.editWalletRewards(body);
   }
 
-  @Get("welcome-traveller-eligible")
+  @Get("airdrop/welcome-traveller-eligible")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiTags("airdrop")
@@ -52,7 +53,7 @@ export class AirdropController {
     return this.airdropService.getWelcomeTravellerEligibleWallets();
   }
 
-  @Get("community-rewards-eligible")
+  @Get("airdrop/community-rewards-eligible")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiTags("airdrop")
@@ -61,7 +62,7 @@ export class AirdropController {
     return this.airdropService.getCommunityRewardsEligibleWallets();
   }
 
-  @Post("upload/rewards")
+  @Post("airdrop/upload/rewards")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @UseInterceptors(
@@ -87,7 +88,7 @@ export class AirdropController {
     });
   }
 
-  @Post("upload/merkle-distributor-recipients")
+  @Post("airdrop/upload/merkle-distributor-recipients")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @UseInterceptors(
@@ -102,16 +103,22 @@ export class AirdropController {
     return this.airdropService.processMerkleDistributorRecipientsFile(file);
   }
 
-  @Get("merkle-distributor-proof")
+  @Get("airdrop/merkle-distributor-proof")
   @ApiTags("airdrop")
   getMerkleDistributorProof(@Query() query: GetMerkleDistributorProofQuery) {
     const includeDiscord = query.includeDiscord === "true";
     return this.airdropService.getMerkleDistributorProof(query.address, query.windowIndex, includeDiscord);
   }
 
-  @Get("merkle-distributor-proofs")
+  @Get("airdrop/merkle-distributor-proofs")
   @ApiTags("airdrop")
   getMerkleDistributorProofs(@Query() query: GetMerkleDistributorProofsQuery) {
     return this.airdropService.getMerkleDistributorProofs(query.address, query.startWindowIndex);
+  }
+
+  @Get("airdrop/etl/merkle-distributor-recipients")
+  @ApiTags("etl")
+  getEtlMerkleDistributorRecipients(@Query() query: GetEtlMerkleDistributorRecipientsQuery) {
+    return this.airdropService.getEtlMerkleDistributorRecipients(query);
   }
 }

--- a/src/modules/airdrop/entry-points/http/dto.ts
+++ b/src/modules/airdrop/entry-points/http/dto.ts
@@ -80,3 +80,9 @@ export class GetMerkleDistributorProofsQuery {
   @IsEthereumAddress()
   address: string;
 }
+
+export class GetEtlMerkleDistributorRecipientsQuery {
+  @ApiProperty({ example: "0" })
+  @IsNumberString({ no_symbols: true })
+  windowIndex: number;
+}

--- a/test/airdrop/merkle-distributor.e2e-spec.ts
+++ b/test/airdrop/merkle-distributor.e2e-spec.ts
@@ -325,3 +325,38 @@ describe("POST /airdrop/upload/merkle-distributor-recipients", () => {
     expect(response.body.recipients).toStrictEqual(2);
   });
 });
+
+describe("GET /airdrop/etl/merkle-distributor-recipients", () => {
+  const url = "/airdrop/etl/merkle-distributor-recipients";
+
+  afterEach(async () => {
+    await merkleDistributorWindowFixture.deleteAllMerkleDistributorWindows();
+    await merkleDistributorRecipientFixture.deleteAllMerkleDistributorRecipients();
+  });
+
+  it("should return recipients formatted for across-etl tasks", async () => {
+    const address = "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd";
+    const window = await merkleDistributorWindowFixture.insertMerkleDistributorWindow({
+      windowIndex: 0,
+      rewardsToDeposit: "10",
+    });
+    await merkleDistributorRecipientFixture.insertMerkleDistributorRecipient({
+      address,
+      amount: "10",
+      merkleDistributorWindowId: window.id,
+      payload: {
+        amountBreakdown: {
+          communityRewards: "2",
+          earlyUserRewards: "2",
+          liquidityProviderRewards: "2",
+          welcomeTravelerRewards: "4",
+          referralRewards: "0",
+        },
+      },
+    });
+    const response = await request(app.getHttpServer()).get(url).query({
+      windowIndex: window.windowIndex,
+    });
+    expect(response.statusCode).toStrictEqual(200);
+  });
+});


### PR DESCRIPTION
This PR adds [the endpoint](https://github.com/across-protocol/scraper-api/pull/216/files#diff-f91b21c92f2c60e94b5de8e3dcf5dc2b4bf31af44d40dc7c6d568ba1835f191eR118-R123) used by across-etl scripts to fetch recipients of the MerkleDistributor airdrop contract