### PR TITLE
feat: add endpoint for discord users linked wallet

### DIFF
--- a/src/modules/user/entry-points/http/user.controller.ts
+++ b/src/modules/user/entry-points/http/user.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Get, Post, Patch, Body, Req, UseGuards } from "@nestjs/common";
-import { ApiTags } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
 import { utils } from "ethers";
 
 import { JwtAuthGuard } from "../../../auth/entry-points/http/jwt.guard";
 import { UserService } from "../../services/user.service";
 import { UserWalletService } from "../../services/user-wallet.service";
 import { UsersWalletsBody } from "./dto";
+import { Role, Roles, RolesGuard } from "../../../auth/entry-points/http/roles";
 
 @Controller("users")
 export class UserController {
@@ -65,5 +66,14 @@ export class UserController {
     });
 
     return { walletAddress: updatedUserWallet.walletAddress };
+  }
+
+  @Get("etl/discord-wallets")
+  @ApiTags("scraper")
+  @Roles(Role.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  public async getEtlDiscordUsersWallet() {
+    return this.userWalletService.getEtlDiscordUsersWallet();
   }
 }

--- a/src/modules/user/services/user-wallet.service.ts
+++ b/src/modules/user/services/user-wallet.service.ts
@@ -132,4 +132,16 @@ export class UserWalletService {
 
     return user;
   }
+
+  public async getEtlDiscordUsersWallet() {
+    const query = this.userWalletRepository
+      .createQueryBuilder("uw")
+      .leftJoinAndSelect("uw.user", "u")
+      .select(["uw.walletAddress", "u.discordId"]);
+    const userWallets = await query.getMany();
+    return userWallets.map((uw) => ({
+      address: uw.walletAddress,
+      discordId: uw.user.discordId,
+    }));
+  }
 }

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -265,6 +265,22 @@ describe("PATCH /users/me/wallets", () => {
   });
 });
 
+describe("GET users/etl/discord-wallet", () => {
+  it("should get discord users wallet", async () => {
+    await userWalletFixture.insertUserWallet({ userId: existingUser.id, walletAddress: "0x" });
+    const adminJwt = app.get(JwtService).sign({ roles: ["admin"] });
+    const response = await request(app.getHttpServer())
+      .get("/users/etl/discord-wallets")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(response.status).toBe(200);
+    expect(response.body.length).toBeGreaterThan(0);
+  });
+
+  afterEach(async () => {
+    await userWalletFixture.deleteAllUserWallets();
+  });
+});
+
 async function createWalletForExistingUser() {
   await request(app.getHttpServer())
     .post("/users/me/wallets")


### PR DESCRIPTION
This PR adds a new endpoint `/users/etl/discord-wallets` used to retrieved the wallets linked by discord users. This endpoint canbe called only with a JWT admin token