### PR TITLE
feat: return `recipientAddr` for /deposits endpoint

### DIFF
--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -168,6 +168,7 @@ export function formatDeposit(deposit: Deposit) {
     destinationChainId: deposit.destinationChainId,
     assetAddr: deposit.tokenAddr,
     depositorAddr: deposit.depositorAddr,
+    recipientAddr: deposit.recipientAddr,
     amount: deposit.amount,
     depositTxHash: deposit.depositTxHash,
     fillTxs: deposit.fillTxs.map(({ hash }) => hash),


### PR DESCRIPTION
The property will be needed on the FE for speeding up v2.5 events. This change should also not break the current FE.