### PR TITLE
fix: add count when retry jobs

### DIFF
--- a/src/modules/scraper/entry-point/http/controller.ts
+++ b/src/modules/scraper/entry-point/http/controller.ts
@@ -171,7 +171,6 @@ export class ScraperController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth()
   async retryFailedJobs(@Body() body: RetryFailedJobsBody) {
-    const { queue } = body;
-    this.scraperQueuesService.retryFailedJobs(queue);
+    await this.scraperQueuesService.retryFailedJobs(body);
   }
 }

--- a/src/modules/scraper/entry-point/http/dto.ts
+++ b/src/modules/scraper/entry-point/http/dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsIn, IsInt, IsString } from "class-validator";
+import { IsIn, IsInt, IsOptional, IsString } from "class-validator";
 import { ScraperQueue } from "../../adapter/messaging";
 
 export class ProcessBlocksBody {
@@ -81,4 +81,9 @@ export class RetryFailedJobsBody {
   @IsIn(Object.values(ScraperQueue))
   @ApiProperty({ enum: ScraperQueue, isArray: false })
   queue: ScraperQueue;
+
+  @IsOptional()
+  @IsInt()
+  @ApiProperty({ example: 0 })
+  count?: number;
 }

--- a/src/modules/scraper/service/ScraperQueuesService.ts
+++ b/src/modules/scraper/service/ScraperQueuesService.ts
@@ -76,13 +76,13 @@ export class ScraperQueuesService {
     if (!q) return;
 
     try {
-      let failedJobs: Job[] = [];
+      const failedJobs: Job[] = [];
       if (body.count > 0) {
         await q.getFailed(0, body.count);
       } else {
         await q.getFailed();
       }
-      
+
       for (const failedJob of failedJobs) {
         await failedJob.retry();
       }


### PR DESCRIPTION
Add an optional `count` parameter to specify how many queue jobs needs to be retried when calling the `scraper/failed-jobs/retry` endpoint.

**Issue**
With the current implementation, if the queue has many failed messages that need to be retried, the NodeJS app runs out of memory 