### PR TITLE
feat: support v2.5 speed ups

### DIFF
--- a/migrations/1686902541959-Deposit.ts
+++ b/migrations/1686902541959-Deposit.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Deposit1686902541959 implements MigrationInterface {
+  name = "Deposit1686902541959";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "deposit" ADD "message" character varying NOT NULL DEFAULT '0x'`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "deposit" DROP COLUMN "message"`);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from "@nestjs/core";
+import { Logger } from "@nestjs/common";
 import helmet from "helmet";
 import { NestExpressApplication } from "@nestjs/platform-express";
 
@@ -30,6 +31,10 @@ async function bootstrap() {
   SwaggerModule.setup("swagger", app, document);
 
   await app.listen(port);
+
+  const logger = new Logger("NestApplication");
+  logger.log(`Listening on port ${port}`);
+  logger.log(`Running in modes: ${config.values.app.runModes}`);
 }
 
 bootstrap();

--- a/src/modules/deposit/adapter/db/deposit-fixture.ts
+++ b/src/modules/deposit/adapter/db/deposit-fixture.ts
@@ -43,6 +43,7 @@ export function mockDepositEntity(overrides: Partial<Deposit>) {
     fillTxs: [] as DepositFillTx[],
     blockNumber: 1,
     acxUsdPrice: "0.1",
+    message: "0x",
     ...overrides,
   };
 }

--- a/src/modules/deposit/model/deposit.entity.ts
+++ b/src/modules/deposit/model/deposit.entity.ts
@@ -34,6 +34,8 @@ export type RequestedSpeedUpDepositTx = {
   blockNumber: number;
   newRelayerFeePct: string;
   depositSourceChainId: number;
+  updatedRecipient?: string;
+  updatedMessage?: string;
 };
 
 @Entity()
@@ -70,6 +72,9 @@ export class Deposit {
 
   @Column()
   recipientAddr: string;
+
+  @Column({ default: "0x" })
+  message: string;
 
   @Column({ default: "pending" })
   status: TransferStatus;

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -179,6 +179,7 @@ export function formatDeposit(deposit: Deposit) {
     assetAddr: deposit.tokenAddr,
     depositorAddr: deposit.depositorAddr,
     recipientAddr: deposit.recipientAddr,
+    message: deposit.message,
     amount: deposit.amount,
     depositTxHash: deposit.depositTxHash,
     fillTxs: deposit.fillTxs.map(({ hash }) => hash),

--- a/src/modules/scraper/adapter/messaging/BlocksEventsConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/BlocksEventsConsumer.ts
@@ -208,9 +208,11 @@ export class BlocksEventsConsumer {
         (contract) => contract.address === address,
       )[0];
 
+      let message: SpeedUpEventsQueueMessage;
+
       if (acrossVersion === "2") {
         const typedEvent = event as RequestedSpeedUpDepositEvent2;
-        const message: SpeedUpEventsQueueMessage = {
+        message = {
           depositSourceChainId: chainId,
           depositId: typedEvent.args.depositId,
           depositor: typedEvent.args.depositor,
@@ -219,8 +221,23 @@ export class BlocksEventsConsumer {
           blockNumber: typedEvent.blockNumber,
           newRelayerFeePct: typedEvent.args.newRelayerFeePct.toString(),
         };
-        await this.scraperQueuesService.publishMessage<SpeedUpEventsQueueMessage>(ScraperQueue.SpeedUpEvents, message);
       } else if (acrossVersion === "2.5") {
+        const typedEvent = event as RequestedSpeedUpDepositEvent2_5;
+        message = {
+          depositSourceChainId: chainId,
+          depositId: typedEvent.args.depositId,
+          depositor: typedEvent.args.depositor,
+          depositorSignature: typedEvent.args.depositorSignature,
+          transactionHash: typedEvent.transactionHash,
+          blockNumber: typedEvent.blockNumber,
+          newRelayerFeePct: typedEvent.args.newRelayerFeePct.toString(),
+          updatedMessage: typedEvent.args.updatedMessage,
+          updatedRecipient: typedEvent.args.updatedRecipient,
+        };
+      }
+
+      if (message) {
+        await this.scraperQueuesService.publishMessage<SpeedUpEventsQueueMessage>(ScraperQueue.SpeedUpEvents, message);
       }
     }
   }

--- a/src/modules/scraper/adapter/messaging/SpeedUpEventsConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/SpeedUpEventsConsumer.ts
@@ -40,11 +40,12 @@ export class SpeedUpEventsConsumer {
   }
 
   public async processSpeedUpEventQueueMessage(deposit: Deposit, data: SpeedUpEventsQueueMessage) {
-    const { transactionHash, newRelayerFeePct, blockNumber, depositSourceChainId } = data;
+    const { transactionHash, newRelayerFeePct, blockNumber, depositSourceChainId, updatedMessage, updatedRecipient } =
+      data;
 
     const sortedSpeedUps = [
       ...deposit.speedUps,
-      { hash: transactionHash, newRelayerFeePct, blockNumber, depositSourceChainId },
+      { hash: transactionHash, newRelayerFeePct, blockNumber, depositSourceChainId, updatedMessage, updatedRecipient },
     ].sort((a, b) => b.blockNumber - a.blockNumber);
 
     return this.depositRepository.update(
@@ -52,6 +53,8 @@ export class SpeedUpEventsConsumer {
       {
         speedUps: sortedSpeedUps,
         depositRelayerFeePct: sortedSpeedUps[0].newRelayerFeePct,
+        message: sortedSpeedUps[0].updatedMessage || deposit.message,
+        recipientAddr: sortedSpeedUps[0]?.updatedRecipient || deposit.recipientAddr,
       },
     );
   }

--- a/src/modules/scraper/adapter/messaging/index.ts
+++ b/src/modules/scraper/adapter/messaging/index.ts
@@ -56,6 +56,8 @@ export type SpeedUpEventsQueueMessage = {
   transactionHash: string;
   blockNumber: number;
   newRelayerFeePct: string;
+  updatedRecipient?: string;
+  updatedMessage?: string;
 };
 
 export type BlockNumberQueueMessage = {


### PR DESCRIPTION
Fixes ACX-1219

For some reason, we didn't adapt the scraper to support the new speed up events of v2.5 of the spoke pools. 