### PR TITLE
fix: retry incomplete deposits

### DIFF
--- a/src/modules/configuration/index.ts
+++ b/src/modules/configuration/index.ts
@@ -58,7 +58,6 @@ export const configValues = () => ({
       421613: process.env.WEB3_NODE_URL_421613,
       5: process.env.WEB3_NODE_URL_5,
       280: process.env.WEB3_NODE_URL_280,
-      324: process.env.WEB3_NODE_URL_324,
     },
     spokePoolContracts: {
       [ChainIds.mainnet]: [
@@ -146,14 +145,6 @@ export const configValues = () => ({
           address: "0x863859ef502F0Ee9676626ED5B418037252eFeb2",
           startBlockNumber: 5000000,
           abi: JSON.stringify(GoerliSpokePool2_5Abi),
-          acrossVersion: "2.5",
-        },
-      ],
-      [ChainIds.zkSyncMainnet]: [
-        {
-          address: "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF",
-          startBlockNumber: 10352565,
-          abi: JSON.stringify(EthereumSpokePool2_5Abi),
           acrossVersion: "2.5",
         },
       ],

--- a/src/modules/configuration/index.ts
+++ b/src/modules/configuration/index.ts
@@ -58,6 +58,7 @@ export const configValues = () => ({
       421613: process.env.WEB3_NODE_URL_421613,
       5: process.env.WEB3_NODE_URL_5,
       280: process.env.WEB3_NODE_URL_280,
+      324: process.env.WEB3_NODE_URL_324,
     },
     spokePoolContracts: {
       [ChainIds.mainnet]: [
@@ -145,6 +146,14 @@ export const configValues = () => ({
           address: "0x863859ef502F0Ee9676626ED5B418037252eFeb2",
           startBlockNumber: 5000000,
           abi: JSON.stringify(GoerliSpokePool2_5Abi),
+          acrossVersion: "2.5",
+        },
+      ],
+      [ChainIds.zkSyncMainnet]: [
+        {
+          address: "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF",
+          startBlockNumber: 10352565,
+          abi: JSON.stringify(EthereumSpokePool2_5Abi),
           acrossVersion: "2.5",
         },
       ],

--- a/src/modules/scraper/entry-point/http/controller.ts
+++ b/src/modules/scraper/entry-point/http/controller.ts
@@ -26,6 +26,7 @@ import {
   SubmitDepositAcxPriceBody,
   SubmitSuggestedFeesBody,
   RetryFailedJobsBody,
+  RetryIncompleteDepositsBody,
 } from "./dto";
 
 @Controller()
@@ -172,5 +173,14 @@ export class ScraperController {
   @ApiBearerAuth()
   async retryFailedJobs(@Body() body: RetryFailedJobsBody) {
     await this.scraperQueuesService.retryFailedJobs(body);
+  }
+
+  @Post("scraper/incomplete-deposits/retry")
+  @ApiTags("scraper")
+  @Roles(Role.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  async retryIncompleteDeposits(@Body() body: RetryIncompleteDepositsBody) {
+    await this.scraperService.retryIncompleteDeposits(body);
   }
 }

--- a/src/modules/scraper/entry-point/http/dto.ts
+++ b/src/modules/scraper/entry-point/http/dto.ts
@@ -87,3 +87,10 @@ export class RetryFailedJobsBody {
   @ApiProperty({ example: 0 })
   count?: number;
 }
+
+export class RetryIncompleteDepositsBody {
+  @IsOptional()
+  @IsInt()
+  @ApiProperty({ example: 0 })
+  count?: number;
+}


### PR DESCRIPTION
Some deposits from the database don't have a deposit date, token id or a price id and this should not happen under any circumstances.

Until I figure out exactly why it happens, I added a new endpoint `/scraper/incomplete-deposits/retry` that queries these deposits and submits them to the `BlockNumber` queue again. This will force the columns to be populated