### PR TITLE
feat: Update docker registry

### DIFF
--- a/cloudbuild-stage.yml
+++ b/cloudbuild-stage.yml
@@ -1,8 +1,8 @@
 steps:
   - name: "gcr.io/cloud-builders/docker"
-    args: ["build", "-t", "gcr.io/images-across-6363/across-api-stage", "."]
+    args: ["build", "-t", "us-east1-docker.pkg.dev/images-across-6363/stage-scraper-api/stage-scraper-api", "."]
 options:
   machineType: "E2_HIGHCPU_8"
 timeout: 3600s
-images: ["gcr.io/images-across-6363/across-api-stage"]
+images: ["us-east1-docker.pkg.dev/images-across-6363/stage-scraper-api/stage-scraper-api"]
 tags: ["stage"]

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,7 +1,7 @@
 steps:
   - name: "gcr.io/cloud-builders/docker"
-    args: ["build", "-t", "gcr.io/images-across-6363/across-api", "."]
+    args: ["build", "-t", "us-east1-docker.pkg.dev/images-across-6363/scraper-api/scraper-api", "."]
 options:
   machineType: "E2_HIGHCPU_8"
 timeout: 3600s
-images: ["gcr.io/images-across-6363/across-api"]
+images: ["us-east1-docker.pkg.dev/images-across-6363/scraper-api/scraper-api"]


### PR DESCRIPTION
Change the docker registry method from GCR to Artifacts due the [near deprecation from GCP](https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation)