### PR TITLE
fix: implement asynchronous jobs for computing referral rewards window

### DIFF
--- a/migrations/1696942295195-ReferralRewardsWindowJob.ts
+++ b/migrations/1696942295195-ReferralRewardsWindowJob.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ReferralRewardsWindowJob1696942295195 implements MigrationInterface {
+  name = "ReferralRewardsWindowJob1696942295195";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "referral_rewards_window_job" (
+        "id" SERIAL NOT NULL, 
+        "windowIndex" integer NOT NULL, 
+        "status" character varying NOT NULL DEFAULT 'Initial', 
+        "config" jsonb NOT NULL, 
+        "error" character varying, 
+        "executionTime" numeric, 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "PK_c6fec40b7e4d76f0be188c6a8c4" PRIMARY KEY ("id")
+      )`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "referral_rewards_window_job"`);
+  }
+}

--- a/migrations/1696942295196-ReferralRewardsWindowJobResult.ts
+++ b/migrations/1696942295196-ReferralRewardsWindowJobResult.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ReferralRewardsWindowJobResult1696942295196 implements MigrationInterface {
+  name = "ReferralRewardsWindowJobResult1696942295196";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "referral_rewards_window_job_result" (
+        "id" SERIAL NOT NULL, 
+        "jobId" integer NOT NULL, 
+        "windowIndex" integer NOT NULL, 
+        "totalRewardsAmount" numeric NOT NULL, 
+        "address" character varying NOT NULL, 
+        "amount" numeric NOT NULL, 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "PK_5f25c5ee5b67b2a5c403fde9168" PRIMARY KEY ("id"))`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "referral_rewards_window_job_result"`);
+  }
+}

--- a/src/modules/database/database.providers.ts
+++ b/src/modules/database/database.providers.ts
@@ -23,6 +23,8 @@ import { FundsDepositedEv } from "../web3/model/funds-deposited-ev.entity";
 import { FilledRelayEv } from "../web3/model/filled-relay-ev.entity";
 import { RequestedSpeedUpDepositEv } from "../web3/model/requested-speed-up-deposit-ev.entity";
 import { RefundRequestedEv } from "../web3/model/refund-requested-ev.entity";
+import { ReferralRewardsWindowJob } from "../referral/model/ReferralRewardsWindowJob.entity";
+import { ReferralRewardsWindowJobResult } from "../referral/model/ReferralRewardsWindowJobResult.entity";
 
 // TODO: Add db entities here
 const entities = [
@@ -48,6 +50,8 @@ const entities = [
   FilledRelayEv,
   RequestedSpeedUpDepositEv,
   RefundRequestedEv,
+  ReferralRewardsWindowJob,
+  ReferralRewardsWindowJobResult,
 ];
 
 @Injectable()

--- a/src/modules/referral/adapter/db/referral-rewards-window-job-fi.ts
+++ b/src/modules/referral/adapter/db/referral-rewards-window-job-fi.ts
@@ -1,0 +1,37 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { ReferralRewardsWindowJob, ReferralRewardsWindowJobStatus } from "../../model/ReferralRewardsWindowJob.entity";
+
+@Injectable()
+export class ReferralRewardsWindowJobFixture {
+  public constructor(
+    @InjectRepository(ReferralRewardsWindowJob)
+    private referralRewardsWindowJobRepository: Repository<ReferralRewardsWindowJob>,
+  ) {}
+
+  public insert(depositArgs: Partial<ReferralRewardsWindowJob>) {
+    const job = this.referralRewardsWindowJobRepository.create(this.mockClaimEntity(depositArgs));
+    return this.referralRewardsWindowJobRepository.save(job);
+  }
+
+  public insertMany(args: Partial<ReferralRewardsWindowJob>[]) {
+    const createdJobs = this.referralRewardsWindowJobRepository.create(args);
+    return this.referralRewardsWindowJobRepository.save(createdJobs);
+  }
+
+  public deleteAll() {
+    return this.referralRewardsWindowJobRepository.query(
+      `truncate table referral_rewards_window_job restart identity cascade`,
+    );
+  }
+
+  public mockClaimEntity(overrides: Partial<ReferralRewardsWindowJob>): Partial<ReferralRewardsWindowJob> {
+    return {
+      windowIndex: 1,
+      status: ReferralRewardsWindowJobStatus.Initial,
+      config: { maxDepositDate: new Date().toISOString() },
+      ...overrides,
+    };
+  }
+}

--- a/src/modules/referral/entry-points/http/controller.ts
+++ b/src/modules/referral/entry-points/http/controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards, Post, Body, Delete } from "@nestjs/common";
+import { Controller, Get, Query, UseGuards, Post, Body, Delete, Param } from "@nestjs/common";
 import { ApiTags, ApiBearerAuth } from "@nestjs/swagger";
 
 import { ReferralService } from "../../services/service";
@@ -7,6 +7,7 @@ import {
   GetReferralsQuery,
   GetReferralsSummaryQuery,
   DeleteReferralsMerkleDistributionBody,
+  GetReferralRewardsWindowJobParams,
 } from "./dto";
 import { JwtAuthGuard } from "../../../auth/entry-points/http/jwt.guard";
 import { Role, Roles, RolesGuard } from "../../../auth/entry-points/http/roles";
@@ -29,14 +30,24 @@ export class ReferralController {
     return this.referralService.getReferrals(query.address, limit, offset);
   }
 
-  @Post("referrals/merkle-distribution")
+  @Post("referral-rewards-window-job")
   @Roles(Role.Admin)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth()
   @ApiTags("referrals")
-  postReferralsMerkleDistribution(@Body() body: PostReferralsMerkleDistributionBody) {
+  createReferralRewardsWindowJob(@Body() body: PostReferralsMerkleDistributionBody) {
     const { maxDepositDate, windowIndex } = body;
-    return this.referralService.createReferralsMerkleDistribution(parseInt(windowIndex), new Date(maxDepositDate));
+    return this.referralService.createReferralRewardsWindowJob(parseInt(windowIndex), new Date(maxDepositDate));
+  }
+
+  @Get("referral-rewards-window-job/:id")
+  @Roles(Role.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiTags("referrals")
+  getReferralRewardsWindowJob(@Param() params: GetReferralRewardsWindowJobParams) {
+    const { id } = params;
+    return this.referralService.getReferralRewardsWindowJob(id);
   }
 
   @Delete("referrals/merkle-distribution")

--- a/src/modules/referral/entry-points/http/dto.ts
+++ b/src/modules/referral/entry-points/http/dto.ts
@@ -40,6 +40,11 @@ export class PostReferralsMerkleDistributionBody {
   windowIndex: string;
 }
 
+export class GetReferralRewardsWindowJobParams {
+  @IsNumberString()
+  id: number;
+}
+
 export class DeleteReferralsMerkleDistributionBody {
   @IsNumberString()
   @ApiProperty({ example: "0", required: true })

--- a/src/modules/referral/model/ReferralRewardsWindowJob.entity.ts
+++ b/src/modules/referral/model/ReferralRewardsWindowJob.entity.ts
@@ -1,0 +1,43 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+
+export enum ReferralRewardsWindowJobStatus {
+  Initial = "Initial",
+  InProgress = "InProgress",
+  Done = "Done",
+  Failed = "Failed",
+}
+
+export type ReferralRewardsWindowJobConfig = {
+  maxDepositDate: string;
+};
+
+/**
+ * @description This class represents a job for creating referral rewards windows
+ */
+@Entity()
+export class ReferralRewardsWindowJob {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  windowIndex: number;
+
+  @Column({ default: ReferralRewardsWindowJobStatus.Initial })
+  status: ReferralRewardsWindowJobStatus;
+
+  @Column({ type: "jsonb" })
+  config: ReferralRewardsWindowJobConfig;
+
+  @Column({ nullable: true })
+  error?: string;
+
+  /** job execution time in seconds */
+  @Column({ type: "decimal", nullable: true })
+  executionTime?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/referral/model/ReferralRewardsWindowJobResult.entity.ts
+++ b/src/modules/referral/model/ReferralRewardsWindowJobResult.entity.ts
@@ -1,0 +1,28 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+
+@Entity()
+export class ReferralRewardsWindowJobResult {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  jobId: number;
+
+  @Column()
+  windowIndex: number;
+
+  @Column({ type: "decimal" })
+  totalRewardsAmount: string;
+
+  @Column()
+  address: string;
+
+  @Column({ type: "decimal" })
+  amount: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/referral/module.ts
+++ b/src/modules/referral/module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module, Provider } from "@nestjs/common";
+import { DynamicModule, Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { AppConfigModule } from "../configuration/configuration.module";
 import { DepositsMv } from "../deposit/model/DepositsMv.entity";
@@ -10,6 +10,7 @@ import { ModuleOptions, RunMode } from "../../dynamic-module";
 import { Web3Module } from "../web3/module";
 import { ReferralRewardsWindowJob } from "./model/ReferralRewardsWindowJob.entity";
 import { ReferralRewardsWindowJobResult } from "./model/ReferralRewardsWindowJobResult.entity";
+import { ReferralRewardsWindowJobFixture } from "./adapter/db/referral-rewards-window-job-fi";
 
 @Module({})
 export class ReferralModule {
@@ -20,7 +21,7 @@ export class ReferralModule {
       module = {
         ...module,
         controllers: [...module.controllers, ReferralController],
-        providers: [...module.providers, ReferralService],
+        providers: [...module.providers, ReferralService, ReferralRewardsWindowJobFixture],
         imports: [
           ...module.imports,
           TypeOrmModule.forFeature([Deposit, DepositsMv, ReferralRewardsWindowJob, ReferralRewardsWindowJobResult]),
@@ -34,7 +35,7 @@ export class ReferralModule {
     if (moduleOptions.runModes.includes(RunMode.Scraper)) {
       module = {
         ...module,
-        providers: [...module.providers, ReferralCronService, ReferralService],
+        providers: [...module.providers, ReferralCronService, ReferralService, ReferralRewardsWindowJobFixture],
         imports: [
           ...module.imports,
           TypeOrmModule.forFeature([Deposit, DepositsMv, ReferralRewardsWindowJob, ReferralRewardsWindowJobResult]),

--- a/src/modules/referral/module.ts
+++ b/src/modules/referral/module.ts
@@ -8,6 +8,8 @@ import { ReferralCronService } from "./services/cron-service";
 import { ReferralService } from "./services/service";
 import { ModuleOptions, RunMode } from "../../dynamic-module";
 import { Web3Module } from "../web3/module";
+import { ReferralRewardsWindowJob } from "./model/ReferralRewardsWindowJob.entity";
+import { ReferralRewardsWindowJobResult } from "./model/ReferralRewardsWindowJobResult.entity";
 
 @Module({})
 export class ReferralModule {
@@ -19,7 +21,12 @@ export class ReferralModule {
         ...module,
         controllers: [...module.controllers, ReferralController],
         providers: [...module.providers, ReferralService],
-        imports: [...module.imports, TypeOrmModule.forFeature([Deposit, DepositsMv]), AppConfigModule, Web3Module],
+        imports: [
+          ...module.imports,
+          TypeOrmModule.forFeature([Deposit, DepositsMv, ReferralRewardsWindowJob, ReferralRewardsWindowJobResult]),
+          AppConfigModule,
+          Web3Module,
+        ],
         exports: [...module.exports, ReferralService],
       };
     }
@@ -28,7 +35,12 @@ export class ReferralModule {
       module = {
         ...module,
         providers: [...module.providers, ReferralCronService, ReferralService],
-        imports: [...module.imports, TypeOrmModule.forFeature([Deposit, DepositsMv]), AppConfigModule, Web3Module],
+        imports: [
+          ...module.imports,
+          TypeOrmModule.forFeature([Deposit, DepositsMv, ReferralRewardsWindowJob, ReferralRewardsWindowJobResult]),
+          AppConfigModule,
+          Web3Module,
+        ],
         exports: [...module.exports, ReferralService],
       };
     }

--- a/src/modules/referral/services/exceptions.ts
+++ b/src/modules/referral/services/exceptions.ts
@@ -11,3 +11,27 @@ export class WindowAlreadySetException extends HttpException {
     );
   }
 }
+
+export class InvalidReferralRewardsWindowJobException extends HttpException {
+  constructor(message: string) {
+    super(
+      {
+        error: InvalidReferralRewardsWindowJobException.name,
+        message,
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}
+
+export class ReferralRewardsWindowJobNotFoundException extends HttpException {
+  constructor(id: number) {
+    super(
+      {
+        error: ReferralRewardsWindowJobNotFoundException.name,
+        message: `Job with id ${id} not found.`,
+      },
+      HttpStatus.NOT_FOUND,
+    );
+  }
+}

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -20,7 +20,11 @@ import {
 } from "./queries";
 import { AppConfig } from "../../configuration/configuration.service";
 import { DepositsMv } from "../../deposit/model/DepositsMv.entity";
-import { WindowAlreadySetException } from "./exceptions";
+import {
+  InvalidReferralRewardsWindowJobException,
+  ReferralRewardsWindowJobNotFoundException,
+  WindowAlreadySetException,
+} from "./exceptions";
 import { DepositsFilteredReferrals } from "../model/DepositsFilteredReferrals.entity";
 import { DepositReferralStat } from "../../deposit/model/deposit-referral-stat.entity";
 import { splitArrayInChunks } from "../../../utils";
@@ -29,6 +33,9 @@ import { EthProvidersService } from "../../web3/services/EthProvidersService";
 import { ChainIds } from "../../web3/model/ChainId";
 import { StickyReferralAddressesMechanism } from "../../configuration";
 import { Transaction } from "../../web3/model/transaction.entity";
+import { ReferralRewardsWindowJob, ReferralRewardsWindowJobStatus } from "../model/ReferralRewardsWindowJob.entity";
+import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
+import { ReferralRewardsWindowJobResult } from "../model/ReferralRewardsWindowJobResult.entity";
 
 const REFERRAL_ADDRESS_DELIMITER = "d00dfeeddeadbeef";
 const getReferralsSummaryCacheKey = (address: string) => `referrals:summary:${address}`;
@@ -39,6 +46,10 @@ export class ReferralService {
 
   constructor(
     @InjectRepository(Deposit) readonly depositRepository: Repository<Deposit>,
+    @InjectRepository(ReferralRewardsWindowJob)
+    readonly referralRewardsWindowJobRepository: Repository<ReferralRewardsWindowJob>,
+    @InjectRepository(ReferralRewardsWindowJobResult)
+    readonly referralRewardsWindowJobResultRepository: Repository<ReferralRewardsWindowJobResult>,
     @InjectRepository(DepositsMv) readonly depositsMvRepository: Repository<DepositsMv>,
     private ethProvidersService: EthProvidersService,
     private appConfig: AppConfig,
@@ -117,8 +128,126 @@ export class ReferralService {
     };
   }
 
-  public async createReferralsMerkleDistribution(windowIndex: number, maxDepositDate: Date) {
-    return this.dataSource.transaction("REPEATABLE READ", async (entityManager) => {
+  public async createNewReferralRewardsWindowJob(windowIndex: number, maxDepositDate: Date) {
+    return this.dataSource.transaction(async (entityManager) => {
+      const jobs = await entityManager
+        .createQueryBuilder(ReferralRewardsWindowJob, "job")
+        .where("job.windowIndex = :windowIndex", { windowIndex })
+        .orderBy({ createdAt: "DESC" })
+        .getMany();
+
+      if (jobs.length > 0 && jobs[0].status === ReferralRewardsWindowJobStatus.Initial) {
+        throw new InvalidReferralRewardsWindowJobException(`Job already created for window ${windowIndex}`);
+      }
+
+      if (jobs.length > 0 && jobs[0].status === ReferralRewardsWindowJobStatus.InProgress) {
+        throw new InvalidReferralRewardsWindowJobException(
+          `Job in progress for window ${windowIndex}. Please wait and try again.`,
+        );
+      }
+
+      if (jobs.length > 0 && jobs[0].status === ReferralRewardsWindowJobStatus.Done) {
+        throw new InvalidReferralRewardsWindowJobException(
+          `Job already exists for window ${windowIndex}. Please create a new window.`,
+        );
+      }
+
+      // A new job for referral rewards window was created.
+      const insertJobResult = await entityManager
+        .createQueryBuilder()
+        .insert()
+        .into(ReferralRewardsWindowJob)
+        .values({
+          windowIndex,
+          status: ReferralRewardsWindowJobStatus.Initial,
+          config: { maxDepositDate: maxDepositDate.toISOString() },
+        })
+        .execute();
+      const jobId = insertJobResult.identifiers[0].id;
+      const job = await entityManager
+        .createQueryBuilder()
+        .select("job")
+        .from(ReferralRewardsWindowJob, "job")
+        .where("job.id = :id", { id: jobId })
+        .getOne();
+
+      return job;
+    });
+  }
+
+  public async updateReferralRewardsWindowJob(id: number, values: QueryDeepPartialEntity<ReferralRewardsWindowJob>) {
+    await this.dataSource
+      .createQueryBuilder()
+      .update(ReferralRewardsWindowJob)
+      .set(values)
+      .where("id = :id", { id })
+      .execute();
+
+    const job = await this.dataSource
+      .createQueryBuilder()
+      .select("job")
+      .from(ReferralRewardsWindowJob, "job")
+      .where("job.id = :id", { id })
+      .getOne();
+
+    return job;
+  }
+
+  public async createReferralRewardsWindowJob(windowIndex: number, maxDepositDate: Date) {
+    let job = await this.createNewReferralRewardsWindowJob(windowIndex, maxDepositDate);
+    job = await this.updateReferralRewardsWindowJob(job.id, { status: ReferralRewardsWindowJobStatus.InProgress });
+
+    const start = new Date().getTime();
+    this.computeReferralRewardsForWindow(job.id, windowIndex, maxDepositDate)
+      .then(() => {
+        const stop = new Date().getTime();
+        this.updateReferralRewardsWindowJob(job.id, {
+          status: ReferralRewardsWindowJobStatus.Done,
+          executionTime: `${(stop - start) / 1000}`,
+        });
+      })
+      .catch((error) => {
+        const stop = new Date().getTime();
+        this.updateReferralRewardsWindowJob(job.id, {
+          status: ReferralRewardsWindowJobStatus.Failed,
+          error: JSON.stringify(error),
+          executionTime: `${(stop - start) / 1000}`,
+        });
+      });
+
+    return job;
+  }
+
+  public async getReferralRewardsWindowJob(id: number) {
+    const job = await this.referralRewardsWindowJobRepository.findOne({ where: { id } });
+
+    if (!job) throw new ReferralRewardsWindowJobNotFoundException(job.id);
+
+    const jobResults = await this.referralRewardsWindowJobResultRepository.find({ where: { jobId: job.id } });
+    const recipients = jobResults.map((result) => ({
+      account: result.address,
+      amount: result.amount,
+      metadata: {
+        amountBreakdown: {
+          referralRewards: result.amount,
+        },
+      },
+    }));
+
+    return {
+      job,
+      result: {
+        chainId: this.appConfig.values.web3.merkleDistributor.chainId,
+        rewardToken: this.appConfig.values.web3.acx.address,
+        windowIndex: job.windowIndex,
+        rewardsToDeposit: jobResults[0].totalRewardsAmount,
+        recipients,
+      },
+    };
+  }
+
+  private computeReferralRewardsForWindow(jobId: number, windowIndex: number, maxDepositDate: Date) {
+    return this.dataSource.transaction(async (entityManager) => {
       const depositWithSameWindowIndex = await entityManager
         .createQueryBuilder(Deposit, "d")
         .where("d.rewardsWindowIndex = :windowIndex", { windowIndex })
@@ -136,7 +265,7 @@ export class ReferralService {
       const { recipients, rewardsToDeposit } = this.calculateReferralRewards(deposits);
 
       for (const depositsChunk of splitArrayInChunks(deposits, 100)) {
-        await this.dataSource
+        await entityManager
           .createQueryBuilder()
           .update(Deposit)
           .set({ rewardsWindowIndex: windowIndex })
@@ -144,13 +273,22 @@ export class ReferralService {
           .execute();
       }
 
-      return {
-        chainId: this.appConfig.values.web3.merkleDistributor.chainId,
-        rewardToken: this.appConfig.values.web3.acx.address,
-        windowIndex,
-        rewardsToDeposit,
-        recipients,
-      };
+      for (const recipientsChunk of splitArrayInChunks(recipients, 100)) {
+        await entityManager
+          .createQueryBuilder()
+          .insert()
+          .into(ReferralRewardsWindowJobResult)
+          .values(
+            recipientsChunk.map((recipient) => ({
+              jobId,
+              windowIndex,
+              totalRewards: rewardsToDeposit,
+              address: recipient.account,
+              rewards: recipient.amount,
+            })),
+          )
+          .execute();
+      }
     });
   }
 
@@ -234,11 +372,6 @@ export class ReferralService {
     const recipients: {
       account: string;
       amount: string;
-      metadata: {
-        amountBreakdown: {
-          referralRewards: string;
-        };
-      };
     }[] = [];
 
     for (const [address, deposits] of Object.entries(addressToDepositsMap)) {
@@ -259,11 +392,6 @@ export class ReferralService {
       recipients.push({
         account: address,
         amount: acxRewards.toFixed(),
-        metadata: {
-          amountBreakdown: {
-            referralRewards: acxRewards.toFixed(),
-          },
-        },
       });
     }
 

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -196,7 +196,7 @@ export class ReferralService {
     this.computeReferralRewardsForWindow(job.id, windowIndex, maxDepositDate)
       .then(() => {
         const stop = new Date().getTime();
-        this.updateReferralRewardsWindowJob(job.id, {
+        return this.updateReferralRewardsWindowJob(job.id, {
           status: ReferralRewardsWindowJobStatus.Done,
           executionTime: `${(stop - start) / 1000}`,
         });


### PR DESCRIPTION
The computation of referral rewards is triggered by calling the POST referrals/merkle-distribution endpoint, but the process is synchronous and the HTTP request waits for the data to be returned. The problem with this approach is that the computation of referral rewards can take a long time and if it takes longer than 100 seconds, the endpoint won't return any data because Cloudflare will throw a timeout error.

With this new approach, the endpoint `POST referral-rewards-window-job` is used to create an asynchronous job which can be queried later for results by calling the  `GET referral-rewards-window-job/:id` endpoint.