### PR TITLE
fix: separate endpoint for pending deposits

### DIFF
--- a/src/modules/deposit/adapter/db/deposit-fixture.ts
+++ b/src/modules/deposit/adapter/db/deposit-fixture.ts
@@ -33,7 +33,7 @@ export function mockDepositEntity(overrides: Partial<Deposit>) {
     depositorAddr: "0x",
     recipientAddr: "0x",
     status: "pending" as TransferStatus,
-    amount: "0",
+    amount: "10",
     filled: "0",
     realizedLpFeePct: "0",
     realizedLpFeePctCapped: "0",

--- a/src/modules/deposit/entry-point/http/controller.ts
+++ b/src/modules/deposit/entry-point/http/controller.ts
@@ -32,4 +32,12 @@ export class DepositController {
   getDepositsStats() {
     return this.depositService.getCachedGeneralStats();
   }
+
+  @Get("deposits/pending")
+  @ApiTags("deposits")
+  getPendingDeposits(@Query() query: GetDepositsQuery) {
+    const limit = parseInt(query.limit ?? "10");
+    const offset = parseInt(query.offset ?? "0");
+    return this.depositService.getPendingDeposits(limit, offset);
+  }
 }

--- a/src/modules/deposit/entry-point/http/dto.ts
+++ b/src/modules/deposit/entry-point/http/dto.ts
@@ -66,3 +66,21 @@ export class GetEtlReferralDepositsQuery {
   @IsDateString()
   date: string;
 }
+
+export class GetPendingDepositsQuery {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  @ApiProperty({ example: 10, required: false })
+  limit: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(10_000_000)
+  @Type(() => Number)
+  @ApiProperty({ example: 0, required: false })
+  offset: string;
+}


### PR DESCRIPTION
Move the logic that returns the pending deposits in a separate endpoint `/deposits/pending` because this logic is quite particular (filter out deposits older than 1 day and unprofitable deposits) and it needs to be taken out from the `/deposits` endpoint which is an endpoint suitable for more general use case.

The endpoint change must be made in the FE too