### PR TITLE
fix: add new endpoint to serve deposits

### DIFF
--- a/src/modules/deposit/entry-point/http/controller.ts
+++ b/src/modules/deposit/entry-point/http/controller.ts
@@ -20,7 +20,7 @@ export class DepositController {
     return this.depositService.getDeposits(query.status, limit, offset);
   }
 
-  @Get("deposits-v2")
+  @Get("v2/deposits")
   getDepositsV2(@Query() query: GetDepositsV2Query) {
     return this.depositService.getDepositsV2(query);
   }

--- a/src/modules/deposit/entry-point/http/controller.ts
+++ b/src/modules/deposit/entry-point/http/controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Query } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { DepositService } from "../../service";
-import { GetDepositsQuery, GetDepositDetailsQuery, GetDepositsStatsResponse } from "./dto";
+import { GetDepositsQuery, GetDepositDetailsQuery, GetDepositsStatsResponse, GetDepositsV2Query } from "./dto";
 
 @Controller()
 export class DepositController {
@@ -18,6 +18,11 @@ export class DepositController {
     }
 
     return this.depositService.getDeposits(query.status, limit, offset);
+  }
+
+  @Get("deposits-v2")
+  getDepositsV2(@Query() query: GetDepositsV2Query) {
+    return this.depositService.getDepositsV2(query);
   }
 
   @Get("deposits/details")

--- a/src/modules/deposit/entry-point/http/dto.ts
+++ b/src/modules/deposit/entry-point/http/dto.ts
@@ -84,3 +84,52 @@ export class GetPendingDepositsQuery {
   @ApiProperty({ example: 0, required: false })
   offset: string;
 }
+
+export class GetDepositsV2Query {
+  @IsOptional()
+  @IsEnum(
+    {
+      FILLED: "filled",
+      PENDING: "pending",
+    },
+    {
+      message: "Must be one of: 'filled', 'pending'",
+    },
+  )
+  @ApiProperty({ example: "filled", required: false })
+  status: "filled" | "pending";
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  @ApiProperty({ example: 10, required: false })
+  limit: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(10_000_000)
+  @Type(() => Number)
+  @ApiProperty({ example: 0, required: false })
+  offset: string;
+
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  @ApiProperty({ example: 0, required: false })
+  originChainId: string;
+
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  @ApiProperty({ example: 0, required: false })
+  destinationChainId: string;
+
+  @IsOptional()
+  @IsString()
+  @Type(() => String)
+  @ApiProperty({ example: "0x", required: true })
+  tokenAddress: string;
+}

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -271,7 +271,7 @@ describe("GET /deposits/pending", () => {
   });
 });
 
-describe("GET /deposits-v2", () => {
+describe("GET /v2/deposits", () => {
   beforeAll(async () => {
     depositFixture = app.get(DepositFixture);
   });
@@ -282,7 +282,7 @@ describe("GET /deposits-v2", () => {
   });
 
   it("200", async () => {
-    const response = await request(app.getHttpServer()).get("/deposits-v2").query({ limit: 10 });
+    const response = await request(app.getHttpServer()).get("/v2/deposits").query({ limit: 10 });
     expect(response.status).toBe(200);
     expect(response.body.deposits).toHaveLength(4);
   });

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -271,6 +271,27 @@ describe("GET /deposits/pending", () => {
   });
 });
 
+describe("GET /deposits-v2", () => {
+  beforeAll(async () => {
+    depositFixture = app.get(DepositFixture);
+  });
+
+  beforeEach(async () => {
+    await depositFixture.insertManyDeposits([{ status: "pending" }, { status: "pending" }]);
+    await depositFixture.insertManyDeposits([{ status: "filled" }, { status: "filled" }]);
+  });
+
+  it("200", async () => {
+    const response = await request(app.getHttpServer()).get("/deposits-v2").query({ limit: 10 });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(4);
+  });
+
+  afterEach(async () => {
+    await app.get(DepositFixture).deleteAllDeposits();
+  });
+});
+
 afterAll(async () => {
   await app.close();
 });


### PR DESCRIPTION
I added a new `GET /deposits-v2` endpoint which is used to serve deposits. This endpoint is intended to replace `/deposits` in time because the old endpoint contains specific logic for some particular filters: for example if deposits are filtered by the `pending` status, it returns only profitable deposits happening in the past 24hrs. This kind of specific logic needs to go to dedicated endpoints, while the new `/deposits-v2` endpoint allows only simple filtering and sorting operations