### PR TITLE
feat: expose `fillTime` in deposits endpoint

### DIFF
--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -233,6 +233,9 @@ export function formatDeposit(deposit: Deposit) {
   return {
     depositId: deposit.depositId,
     depositTime: Math.round(DateTime.fromISO(deposit.depositDate.toISOString()).toSeconds()),
+    fillTime: deposit.filledDate
+      ? Math.round(DateTime.fromISO(deposit.filledDate.toISOString()).toSeconds())
+      : undefined,
     status: deposit.status,
     filled: deposit.filled,
     sourceChainId: deposit.sourceChainId,


### PR DESCRIPTION
Closes ACX-1670

On the FE, we make use of the `fillTime` in the new deposits table.