### PR TITLE
fix: add endpoint for referral rate

### DIFF
--- a/src/modules/referral/entry-points/http/controller.ts
+++ b/src/modules/referral/entry-points/http/controller.ts
@@ -19,7 +19,7 @@ export class ReferralController {
   @Get("referrals/summary")
   @ApiTags("referrals")
   getReferralSummary(@Query() query: GetReferralsSummaryQuery) {
-    return this.referralService.getReferralSummary(query.address);
+    return this.referralService.getReferralSummaryHandler(query);
   }
 
   @Get("referrals/details")

--- a/src/modules/referral/entry-points/http/dto.ts
+++ b/src/modules/referral/entry-points/http/dto.ts
@@ -1,12 +1,18 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsDateString, IsInt, IsNumberString, IsString, Length, Max, Min } from "class-validator";
+import { IsArray, IsDateString, IsInt, IsNumberString, IsOptional, IsString, Length, Max, Min } from "class-validator";
 
 export class GetReferralsSummaryQuery {
   @IsString()
   @Length(42, 42)
   @ApiProperty({ example: "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D", minLength: 42, maxLength: 42, required: true })
   address: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @Type(() => String)
+  fields?: string[];
 }
 
 export class GetReferralsQuery {

--- a/src/modules/referral/services/cron-service.ts
+++ b/src/modules/referral/services/cron-service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { Repository } from "typeorm";
 import { InjectRepository } from "@nestjs/typeorm";
+import { CronExpression } from "@nestjs/schedule";
 import { AppConfig } from "../../configuration/configuration.service";
 import { Deposit } from "../../deposit/model/deposit.entity";
 import { EnhancedCron } from "../../../utils";
@@ -19,7 +20,7 @@ export class ReferralCronService {
     private referralService: ReferralService,
   ) {}
 
-  @EnhancedCron("0 */30 * * * *")
+  @EnhancedCron(CronExpression.EVERY_6_HOURS)
   async startCrons() {
     try {
       if (this.semaphore) return;

--- a/test/referrals.e2e-spec.ts
+++ b/test/referrals.e2e-spec.ts
@@ -209,6 +209,15 @@ describe("GET /referrals/summary", () => {
     expect(response.body.tier).toBe(1);
   });
 
+  it("return only referral rate field", async () => {
+    const response = await request(app.getHttpServer()).get(
+      `/referrals/summary?address=${referrer}&fields[]=referralRate&fields[]=tier`,
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.referralRate).toBe(0.4);
+    expect(Object.keys(response.body).length).toBe(2);
+  });
+
   it("return tier 2 by num transfers", async () => {
     await depositFixture.insertManyDeposits(
       Array.from(Array(3).keys()).map((i) =>


### PR DESCRIPTION
This PR adds the `fields` query parameter to the `/referrals/summary` endpoint which allows to fetch only a subset of the fields returned by the endpoint.  

`GET /referrals/summary?address=${referrer}&fields[]=referralRate&fields[]=tier` endpoint returns only the referral rate and the referral tier