### PR TITLE
fix: use `andWhere` for v2 deposits handler

### DIFF
--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -136,21 +136,21 @@ export class DepositService {
     queryBuilder = queryBuilder.where("d.depositDate is not null");
 
     if (query.status) {
-      queryBuilder = queryBuilder.where("d.status = :status", { status: query.status });
+      queryBuilder = queryBuilder.andWhere("d.status = :status", { status: query.status });
     }
 
     if (query.originChainId) {
-      queryBuilder = queryBuilder.where("d.sourceChainId = :sourceChainId", { sourceChainId: query.originChainId });
+      queryBuilder = queryBuilder.andWhere("d.sourceChainId = :sourceChainId", { sourceChainId: query.originChainId });
     }
 
     if (query.destinationChainId) {
-      queryBuilder = queryBuilder.where("d.destinationChainId = :destinationChainId", {
+      queryBuilder = queryBuilder.andWhere("d.destinationChainId = :destinationChainId", {
         destinationChainId: query.destinationChainId,
       });
     }
 
     if (query.tokenAddress) {
-      queryBuilder = queryBuilder.where("d.tokenAddr = :tokenAddr", { tokenAddr: query.tokenAddress });
+      queryBuilder = queryBuilder.andWhere("d.tokenAddr = :tokenAddr", { tokenAddr: query.tokenAddress });
     }
 
     queryBuilder = queryBuilder.orderBy("d.depositDate", "DESC");

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -287,6 +287,12 @@ describe("GET /v2/deposits", () => {
     expect(response.body.deposits).toHaveLength(4);
   });
 
+  it("200 for correct filter params", async () => {
+    const response = await request(app.getHttpServer()).get("/v2/deposits").query({ status: "filled" });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(1);
+  });
+
   afterEach(async () => {
     await app.get(DepositFixture).deleteAllDeposits();
   });


### PR DESCRIPTION
When using filter query params in the `/v2/deposits` endpoint, the Scraper throws
```
TypeError: Cannot read properties of null (reading 'toISOString')
```
and returns a `500`  because the `depositDate` field is `null`. This is caused due to the usage of `where` instead `andWhere` which overrode the initial query condition `d.depositDate is not null`.