### PR TITLE
feat: new `/deposits/tx-page` endpoint for FE

### DIFF
--- a/src/modules/deposit/entry-point/http/controller.ts
+++ b/src/modules/deposit/entry-point/http/controller.ts
@@ -23,17 +23,27 @@ export class DepositController {
   @Get("deposits")
   @ApiTags("deposits")
   getDeposits(@Query() query: GetDepositsQuery) {
-    return this.depositService.getDepositsForTxPage({
-      userAddress: query.address || undefined,
-      status: query.status,
-      limit: query.limit,
-      offset: query.offset,
-    });
+    const limit = parseInt(query.limit ?? "10");
+    const offset = parseInt(query.offset ?? "0");
+
+    if (query.address) {
+      return this.depositService.getUserDeposits(query.address, query.status, limit, offset);
+    }
+
+    return this.depositService.getDeposits(query.status, limit, offset);
   }
 
   @Get("v2/deposits")
   getDepositsV2(@Query() query: GetDepositsV2Query) {
     return this.depositService.getDepositsV2(query);
+  }
+
+  @Get("deposits/pending")
+  @ApiTags("deposits")
+  getPendingDeposits(@Query() query: GetDepositsQuery) {
+    const limit = parseInt(query.limit ?? "10");
+    const offset = parseInt(query.offset ?? "0");
+    return this.depositService.getPendingDeposits(limit, offset);
   }
 
   @Get("deposits/details")

--- a/src/modules/deposit/entry-point/http/controller.ts
+++ b/src/modules/deposit/entry-point/http/controller.ts
@@ -1,23 +1,34 @@
 import { Controller, Get, Query } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { DepositService } from "../../service";
-import { GetDepositsQuery, GetDepositDetailsQuery, GetDepositsStatsResponse, GetDepositsV2Query } from "./dto";
+import {
+  GetDepositsQuery,
+  GetDepositDetailsQuery,
+  GetDepositsStatsResponse,
+  GetDepositsV2Query,
+  GetDepositsForTxPageQuery,
+} from "./dto";
 
 @Controller()
 export class DepositController {
   public constructor(private depositService: DepositService) {}
 
+  @Get("deposits/tx-page")
+  @ApiTags("deposits")
+  getDepositsForTxPage(@Query() query: GetDepositsForTxPageQuery) {
+    return this.depositService.getDepositsForTxPage(query);
+  }
+
+  // TODO: Deprecate this endpoint if FE migrated to above `/deposits/tx-page` endpoint
   @Get("deposits")
   @ApiTags("deposits")
   getDeposits(@Query() query: GetDepositsQuery) {
-    const limit = parseInt(query.limit ?? "10");
-    const offset = parseInt(query.offset ?? "0");
-
-    if (query.address) {
-      return this.depositService.getUserDeposits(query.address, query.status, limit, offset);
-    }
-
-    return this.depositService.getDeposits(query.status, limit, offset);
+    return this.depositService.getDepositsForTxPage({
+      userAddress: query.address || undefined,
+      status: query.status,
+      limit: query.limit,
+      offset: query.offset,
+    });
   }
 
   @Get("v2/deposits")
@@ -36,13 +47,5 @@ export class DepositController {
   @ApiResponse({ type: GetDepositsStatsResponse })
   getDepositsStats() {
     return this.depositService.getCachedGeneralStats();
-  }
-
-  @Get("deposits/pending")
-  @ApiTags("deposits")
-  getPendingDeposits(@Query() query: GetDepositsQuery) {
-    const limit = parseInt(query.limit ?? "10");
-    const offset = parseInt(query.offset ?? "0");
-    return this.depositService.getPendingDeposits(limit, offset);
   }
 }

--- a/src/modules/deposit/entry-point/http/controller.ts
+++ b/src/modules/deposit/entry-point/http/controller.ts
@@ -38,14 +38,6 @@ export class DepositController {
     return this.depositService.getDepositsV2(query);
   }
 
-  @Get("deposits/pending")
-  @ApiTags("deposits")
-  getPendingDeposits(@Query() query: GetDepositsQuery) {
-    const limit = parseInt(query.limit ?? "10");
-    const offset = parseInt(query.offset ?? "0");
-    return this.depositService.getPendingDeposits(limit, offset);
-  }
-
   @Get("deposits/details")
   @ApiTags("deposits")
   getDepositsDetails(@Query() query: GetDepositDetailsQuery) {
@@ -57,5 +49,13 @@ export class DepositController {
   @ApiResponse({ type: GetDepositsStatsResponse })
   getDepositsStats() {
     return this.depositService.getCachedGeneralStats();
+  }
+
+  @Get("deposits/pending")
+  @ApiTags("deposits")
+  getPendingDeposits(@Query() query: GetDepositsQuery) {
+    const limit = parseInt(query.limit ?? "10");
+    const offset = parseInt(query.offset ?? "0");
+    return this.depositService.getPendingDeposits(limit, offset);
   }
 }

--- a/src/modules/deposit/entry-point/http/dto.ts
+++ b/src/modules/deposit/entry-point/http/dto.ts
@@ -132,6 +132,14 @@ export class GetDepositsV2Query {
   @Type(() => String)
   @ApiProperty({ example: "0x", required: false })
   tokenAddress: string;
+}
+
+export class GetDepositsForTxPageQuery extends GetDepositsV2Query {
+  @IsOptional()
+  @IsString()
+  @Type(() => String)
+  @ApiProperty({ example: "0x", required: false })
+  userAddress: string;
 
   @IsOptional()
   @IsBoolean()

--- a/src/modules/deposit/entry-point/http/dto.ts
+++ b/src/modules/deposit/entry-point/http/dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Max, Min, IsPositive } from "class-validator";
+import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Max, Min, IsPositive, IsBoolean } from "class-validator";
 
 export class GetDepositsQuery {
   @IsOptional()
@@ -130,6 +130,24 @@ export class GetDepositsV2Query {
   @IsOptional()
   @IsString()
   @Type(() => String)
-  @ApiProperty({ example: "0x", required: true })
+  @ApiProperty({ example: "0x", required: false })
   tokenAddress: string;
+
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  @ApiProperty({ example: "true", required: false })
+  skipOldUnprofitable: boolean;
+
+  @IsOptional()
+  @IsEnum(
+    {
+      STATUS: "status",
+    },
+    {
+      message: "Must be one of: 'status'",
+    },
+  )
+  @ApiProperty({ example: "status", required: false })
+  orderBy: "status";
 }

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -153,7 +153,9 @@ export class DepositService {
       queryBuilder = queryBuilder.andWhere("d.tokenAddr = :tokenAddr", { tokenAddr: query.tokenAddress });
     }
 
-    // filter out pending deposits older than 1 day because the relayer will ignore such deposits using its fixed lookback
+    // If this flag is set to true, we will skip pending deposits that:
+    // - are older than 1 day because the relayer will ignore such deposits using its fixed lookback
+    // - or are unprofitable for the relayer
     if (query.skipOldUnprofitable) {
       queryBuilder = queryBuilder.andWhere(
         `

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -13,7 +13,7 @@ import {
 } from "./adapter/db/queries";
 import { AppConfig } from "../configuration/configuration.service";
 import { InvalidAddressException, DepositNotFoundException } from "./exceptions";
-import { GetDepositsV2Query } from "./entry-point/http/dto";
+import { GetDepositsV2Query, GetDepositsForTxPageQuery } from "./entry-point/http/dto";
 
 export const DEPOSITS_STATS_CACHE_KEY = "deposits:stats";
 
@@ -45,113 +45,31 @@ export class DepositService {
     return data;
   }
 
-  public async getUserDeposits(userAddress: string, status?: "filled" | "pending", limit = 10, offset = 0) {
-    try {
-      userAddress = utils.getAddress(userAddress);
-    } catch (error) {
-      throw new InvalidAddressException();
-    }
-
-    let query = this.depositRepository.createQueryBuilder("d");
-    query = query.where("d.depositDate is not null");
-    query = query.andWhere(
-      new Brackets((qb) => {
-        qb.where("d.depositorAddr = :userAddress", {
-          userAddress,
-        }).orWhere("d.recipientAddr = :userAddress", { userAddress });
-      }),
-    );
-
-    if (status) {
-      query = query.andWhere("d.status = :status", { status });
-    }
-
-    query = query.orderBy("d.depositDate", "DESC");
-    query = query.take(limit);
-    query = query.skip(offset);
-
-    const [userDeposits, total] = await query.getManyAndCount();
-
-    return {
-      deposits: userDeposits.map(formatDeposit),
-      pagination: {
-        limit,
-        offset,
-        total,
-      },
-    };
-  }
-
-  public async getDeposits(status: "filled" | "pending", limit = 10, offset = 0) {
-    let deposits: Deposit[] = [];
-    let total = 0;
-
-    if (status === "filled") {
-      [deposits, total] = await this.depositRepository
-        .createQueryBuilder("d")
-        .where("d.status = :status", { status })
-        .andWhere("d.depositDate is not null")
-        .orderBy("d.depositDate", "DESC")
-        .take(limit)
-        .skip(offset)
-        .getManyAndCount();
-    } else if (status === "pending") {
-      // filter out pending deposits older than 1 day because the relayer will ignore such deposits using its fixed lookback
-      [deposits, total] = await this.depositRepository
-        .createQueryBuilder("d")
-        .where("d.status = :status", { status })
-        .andWhere("d.amount > 0")
-        .andWhere("d.depositDate > NOW() - INTERVAL '1 days'")
-        .andWhere(`d.depositRelayerFeePct * :multiplier >= d.suggestedRelayerFeePct`, {
-          multiplier: this.appConfig.values.suggestedFees.deviationBufferMultiplier,
-        })
-        .orderBy("d.depositDate", "DESC")
-        .take(limit)
-        .skip(offset)
-        .getManyAndCount();
-    } else {
-      [deposits, total] = await this.depositRepository
-        .createQueryBuilder("d")
-        .where("d.depositDate is not null")
-        .orderBy("d.depositDate", "DESC")
-        .take(limit)
-        .skip(offset)
-        .getManyAndCount();
-    }
-
-    return {
-      deposits: deposits.map(formatDeposit),
-      pagination: {
-        limit,
-        offset,
-        total,
-      },
-    };
-  }
-
-  public async getDepositsV2(query: GetDepositsV2Query) {
+  public async getDepositsForTxPage(query: Partial<GetDepositsForTxPageQuery>) {
     const limit = parseInt(query.limit ?? "10");
     const offset = parseInt(query.offset ?? "0");
+
     let queryBuilder = this.depositRepository.createQueryBuilder("d");
-    queryBuilder = queryBuilder.where("d.depositDate is not null");
 
-    if (query.status) {
-      queryBuilder = queryBuilder.andWhere("d.status = :status", { status: query.status });
+    if (query.userAddress) {
+      let userAddress = query.userAddress;
+
+      try {
+        userAddress = utils.getAddress(userAddress);
+      } catch (error) {
+        throw new InvalidAddressException();
+      }
+
+      queryBuilder = queryBuilder.andWhere(
+        new Brackets((qb) => {
+          qb.where("d.depositorAddr = :userAddress", {
+            userAddress,
+          }).orWhere("d.recipientAddr = :userAddress", { userAddress });
+        }),
+      );
     }
 
-    if (query.originChainId) {
-      queryBuilder = queryBuilder.andWhere("d.sourceChainId = :sourceChainId", { sourceChainId: query.originChainId });
-    }
-
-    if (query.destinationChainId) {
-      queryBuilder = queryBuilder.andWhere("d.destinationChainId = :destinationChainId", {
-        destinationChainId: query.destinationChainId,
-      });
-    }
-
-    if (query.tokenAddress) {
-      queryBuilder = queryBuilder.andWhere("d.tokenAddr = :tokenAddr", { tokenAddr: query.tokenAddress });
-    }
+    queryBuilder = this._getFilteredDepositsQuery(queryBuilder, query);
 
     // If this flag is set to true, we will skip pending deposits that:
     // - are older than 1 day because the relayer will ignore such deposits using its fixed lookback
@@ -184,6 +102,7 @@ export class DepositService {
     queryBuilder = queryBuilder.addOrderBy("d.depositDate", "DESC");
     queryBuilder = queryBuilder.take(limit);
     queryBuilder = queryBuilder.skip(offset);
+
     const [deposits, total] = await queryBuilder.getManyAndCount();
 
     return {
@@ -196,20 +115,14 @@ export class DepositService {
     };
   }
 
-  public async getPendingDeposits(limit = 10, offset = 0) {
-    // filter out pending deposits older than 1 day because the relayer will ignore such deposits using its fixed lookback
-    const [deposits, total] = await this.depositRepository
-      .createQueryBuilder("d")
-      .where("d.status = :status", { status: "pending" })
-      .andWhere("d.amount > 0")
-      .andWhere("d.depositDate > NOW() - INTERVAL '1 days'")
-      .andWhere(`d.depositRelayerFeePct * :multiplier >= d.suggestedRelayerFeePct`, {
-        multiplier: this.appConfig.values.suggestedFees.deviationBufferMultiplier,
-      })
-      .orderBy("d.depositDate", "DESC")
-      .take(limit)
-      .skip(offset)
-      .getManyAndCount();
+  public async getDepositsV2(query: GetDepositsV2Query) {
+    const limit = parseInt(query.limit ?? "10");
+    const offset = parseInt(query.offset ?? "0");
+
+    let queryBuilder = this.depositRepository.createQueryBuilder("d");
+    queryBuilder = this._getFilteredDepositsQuery(queryBuilder, query);
+
+    const [deposits, total] = await queryBuilder.getManyAndCount();
 
     return {
       deposits: deposits.map(formatDeposit),
@@ -249,6 +162,33 @@ export class DepositService {
       acx_rewards_amount_referrer: d.acxRewardsAmountReferrer,
       acx_rewards_amount_referee: d.acxRewardsAmountReferee,
     }));
+  }
+
+  private _getFilteredDepositsQuery(
+    queryBuilder: ReturnType<typeof this.depositRepository.createQueryBuilder>,
+    filter: Partial<GetDepositsV2Query>,
+  ) {
+    queryBuilder = queryBuilder.andWhere("d.depositDate is not null");
+
+    if (filter.status) {
+      queryBuilder = queryBuilder.andWhere("d.status = :status", { status: filter.status });
+    }
+
+    if (filter.originChainId) {
+      queryBuilder = queryBuilder.andWhere("d.sourceChainId = :sourceChainId", { sourceChainId: filter.originChainId });
+    }
+
+    if (filter.destinationChainId) {
+      queryBuilder = queryBuilder.andWhere("d.destinationChainId = :destinationChainId", {
+        destinationChainId: filter.destinationChainId,
+      });
+    }
+
+    if (filter.tokenAddress) {
+      queryBuilder = queryBuilder.andWhere("d.tokenAddr = :tokenAddr", { tokenAddr: filter.tokenAddress });
+    }
+
+    return queryBuilder;
   }
 }
 

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -69,7 +69,7 @@ export class DepositService {
       );
     }
 
-    queryBuilder = this._getFilteredDepositsQuery(queryBuilder, query);
+    queryBuilder = this.getFilteredDepositsQuery(queryBuilder, query);
 
     // If this flag is set to true, we will skip pending deposits that:
     // - are older than 1 day because the relayer will ignore such deposits using its fixed lookback
@@ -204,7 +204,11 @@ export class DepositService {
     const offset = parseInt(query.offset ?? "0");
 
     let queryBuilder = this.depositRepository.createQueryBuilder("d");
-    queryBuilder = this._getFilteredDepositsQuery(queryBuilder, query);
+    queryBuilder = this.getFilteredDepositsQuery(queryBuilder, query);
+
+    queryBuilder = queryBuilder.orderBy("d.depositDate", "DESC");
+    queryBuilder = queryBuilder.take(limit);
+    queryBuilder = queryBuilder.skip(offset);
 
     const [deposits, total] = await queryBuilder.getManyAndCount();
 
@@ -273,7 +277,7 @@ export class DepositService {
     }));
   }
 
-  private _getFilteredDepositsQuery(
+  private getFilteredDepositsQuery(
     queryBuilder: ReturnType<typeof this.depositRepository.createQueryBuilder>,
     filter: Partial<GetDepositsV2Query>,
   ) {

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -115,6 +115,90 @@ export class DepositService {
     };
   }
 
+  public async getUserDeposits(userAddress: string, status?: "filled" | "pending", limit = 10, offset = 0) {
+    try {
+      userAddress = utils.getAddress(userAddress);
+    } catch (error) {
+      throw new InvalidAddressException();
+    }
+
+    let query = this.depositRepository.createQueryBuilder("d");
+    query = query.where("d.depositDate is not null");
+    query = query.andWhere(
+      new Brackets((qb) => {
+        qb.where("d.depositorAddr = :userAddress", {
+          userAddress,
+        }).orWhere("d.recipientAddr = :userAddress", { userAddress });
+      }),
+    );
+
+    if (status) {
+      query = query.andWhere("d.status = :status", { status });
+    }
+
+    query = query.orderBy("d.depositDate", "DESC");
+    query = query.take(limit);
+    query = query.skip(offset);
+
+    const [userDeposits, total] = await query.getManyAndCount();
+
+    return {
+      deposits: userDeposits.map(formatDeposit),
+      pagination: {
+        limit,
+        offset,
+        total,
+      },
+    };
+  }
+
+  public async getDeposits(status: "filled" | "pending", limit = 10, offset = 0) {
+    let deposits: Deposit[] = [];
+    let total = 0;
+
+    if (status === "filled") {
+      [deposits, total] = await this.depositRepository
+        .createQueryBuilder("d")
+        .where("d.status = :status", { status })
+        .andWhere("d.depositDate is not null")
+        .orderBy("d.depositDate", "DESC")
+        .take(limit)
+        .skip(offset)
+        .getManyAndCount();
+    } else if (status === "pending") {
+      // filter out pending deposits older than 1 day because the relayer will ignore such deposits using its fixed lookback
+      [deposits, total] = await this.depositRepository
+        .createQueryBuilder("d")
+        .where("d.status = :status", { status })
+        .andWhere("d.amount > 0")
+        .andWhere("d.depositDate > NOW() - INTERVAL '1 days'")
+        .andWhere(`d.depositRelayerFeePct * :multiplier >= d.suggestedRelayerFeePct`, {
+          multiplier: this.appConfig.values.suggestedFees.deviationBufferMultiplier,
+        })
+        .orderBy("d.depositDate", "DESC")
+        .take(limit)
+        .skip(offset)
+        .getManyAndCount();
+    } else {
+      [deposits, total] = await this.depositRepository
+        .createQueryBuilder("d")
+        .where("d.depositDate is not null")
+        .orderBy("d.depositDate", "DESC")
+        .take(limit)
+        .skip(offset)
+        .getManyAndCount();
+    }
+
+    return {
+      deposits: deposits.map(formatDeposit),
+      pagination: {
+        limit,
+        offset,
+        total,
+      },
+    };
+  }
+
   public async getDepositsV2(query: GetDepositsV2Query) {
     const limit = parseInt(query.limit ?? "10");
     const offset = parseInt(query.offset ?? "0");
@@ -123,6 +207,31 @@ export class DepositService {
     queryBuilder = this._getFilteredDepositsQuery(queryBuilder, query);
 
     const [deposits, total] = await queryBuilder.getManyAndCount();
+
+    return {
+      deposits: deposits.map(formatDeposit),
+      pagination: {
+        limit,
+        offset,
+        total,
+      },
+    };
+  }
+
+  public async getPendingDeposits(limit = 10, offset = 0) {
+    // filter out pending deposits older than 1 day because the relayer will ignore such deposits using its fixed lookback
+    const [deposits, total] = await this.depositRepository
+      .createQueryBuilder("d")
+      .where("d.status = :status", { status: "pending" })
+      .andWhere("d.amount > 0")
+      .andWhere("d.depositDate > NOW() - INTERVAL '1 days'")
+      .andWhere(`d.depositRelayerFeePct * :multiplier >= d.suggestedRelayerFeePct`, {
+        multiplier: this.appConfig.values.suggestedFees.deviationBufferMultiplier,
+      })
+      .orderBy("d.depositDate", "DESC")
+      .take(limit)
+      .skip(offset)
+      .getManyAndCount();
 
     return {
       deposits: deposits.map(formatDeposit),

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -278,23 +278,85 @@ describe("GET /v2/deposits", () => {
 
   beforeEach(async () => {
     await depositFixture.insertManyDeposits([
-      { status: "pending" },
-      { status: "pending" },
-      { status: "filled" },
-      { status: "filled" },
+      {
+        depositId: 1,
+        status: "pending",
+        sourceChainId: 1,
+        destinationChainId: 10,
+        // unprofitable deposit
+        depositDate: new Date("2021-01-01"),
+        depositRelayerFeePct: "0",
+        suggestedRelayerFeePct: "1",
+      },
+      {
+        depositId: 2,
+        status: "pending",
+        sourceChainId: 137,
+        destinationChainId: 42161,
+        depositDate: new Date(Date.now()),
+        depositRelayerFeePct: "2",
+        suggestedRelayerFeePct: "1",
+      },
+      {
+        depositId: 3,
+        status: "filled",
+        sourceChainId: 1,
+        destinationChainId: 10,
+        tokenAddr: usdc.address,
+        depositDate: new Date(Date.now() - 30_000),
+        depositRelayerFeePct: "2",
+        suggestedRelayerFeePct: "1",
+      },
+      {
+        depositId: 4,
+        status: "filled",
+        sourceChainId: 137,
+        destinationChainId: 42161,
+        depositDate: new Date(Date.now()),
+        depositRelayerFeePct: "2",
+        suggestedRelayerFeePct: "1",
+      },
     ]);
   });
 
-  it("200", async () => {
-    const response = await request(app.getHttpServer()).get("/v2/deposits").query({ limit: 10 });
+  it("200 without query params", async () => {
+    const response = await request(app.getHttpServer()).get("/v2/deposits");
     expect(response.status).toBe(200);
     expect(response.body.deposits).toHaveLength(4);
   });
 
-  it("200 for correct filter params", async () => {
+  it("200 for 'status' query params", async () => {
     const response = await request(app.getHttpServer()).get("/v2/deposits").query({ status: "filled" });
     expect(response.status).toBe(200);
     expect(response.body.deposits).toHaveLength(2);
+  });
+
+  it("200 for 'originChainId' and 'destinationChainId' query params", async () => {
+    const response = await request(app.getHttpServer())
+      .get("/v2/deposits")
+      .query({ originChainId: 1, destinationChainId: 10 });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(2);
+  });
+
+  it("200 for 'tokenAddress' query params", async () => {
+    const response = await request(app.getHttpServer()).get("/v2/deposits").query({ tokenAddress: usdc.address });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(1);
+  });
+
+  it("200 for 'skipOldUnprofitable' query params", async () => {
+    const response = await request(app.getHttpServer()).get("/v2/deposits").query({ skipOldUnprofitable: true });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(3);
+  });
+
+  it("200 for 'orderBy' query params", async () => {
+    const response = await request(app.getHttpServer()).get("/v2/deposits").query({ orderBy: "status" });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(4);
+    expect(response.body.deposits[0].depositId).toBe(2);
+    expect(response.body.deposits[2].depositId).toBe(4);
   });
 
   afterEach(async () => {

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -234,6 +234,43 @@ describe("GET /etl/referral-deposits", () => {
   });
 });
 
+describe("GET /deposits/pending", () => {
+  beforeAll(async () => {
+    depositFixture = app.get(DepositFixture);
+  });
+
+  beforeEach(async () => {
+    await depositFixture.insertManyDeposits([
+      { status: "pending", depositRelayerFeePct: "0.1", suggestedRelayerFeePct: "0.1" },
+      { status: "pending", depositRelayerFeePct: "0.1", suggestedRelayerFeePct: "0.1" },
+    ]);
+    await depositFixture.insertManyDeposits([
+      { status: "filled", depositRelayerFeePct: "0.1", suggestedRelayerFeePct: "0.1" },
+      { status: "filled", depositRelayerFeePct: "0.1", suggestedRelayerFeePct: "0.1" },
+    ]);
+  });
+
+  it("should get pending deposits", async () => {
+    const response = await request(app.getHttpServer()).get("/deposits/pending");
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(2);
+    expect(response.body.pagination).toMatchObject({ limit: 10, offset: 0 });
+  });
+
+  it("400 for invalid offset", async () => {
+    const response = await request(app.getHttpServer()).get("/deposits/pending?offset=invalid");
+    expect(response.status).toBe(400);
+  });
+  it("400 for invalid limit", async () => {
+    const response = await request(app.getHttpServer()).get("/deposits/pending?limit=invalid");
+    expect(response.status).toBe(400);
+  });
+
+  afterEach(async () => {
+    await app.get(DepositFixture).deleteAllDeposits();
+  });
+});
+
 describe("GET /v2/deposits", () => {
   beforeAll(async () => {
     depositFixture = app.get(DepositFixture);


### PR DESCRIPTION
During QA of the new transactions page here https://github.com/across-protocol/frontend-v2/pull/910, new requirements were:
- add more filters in the future
- and have a single deposits table that shows pending deposits first and then sorts by date

This PR adds these functionality to the new `/deposits/tx-page` endpoint.