### PR TITLE
fix: refactor referral address mechanism

### DIFF
--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -489,11 +489,7 @@ export class ReferralService {
     }
 
     // Compute the sticky referral address
-    const stickyReferralAddress = await this.getStickyReferralAddress(deposit);
-    await this.depositRepository.update(
-      { id: deposit.id },
-      { referralAddress: null, stickyReferralAddress: stickyReferralAddress || null },
-    );
+    await this.getStickyReferralAddress(deposit);
   }
 
   public async getStickyReferralAddress(deposit: Deposit) {
@@ -508,8 +504,10 @@ export class ReferralService {
         depositDate: "DESC",
       },
     });
-
-    return previousDepositWithReferralAddress?.referralAddress;
+    await this.depositRepository.update(
+      { id: deposit.id },
+      { referralAddress: null, stickyReferralAddress: previousDepositWithReferralAddress?.referralAddress || null },
+    );
   }
 
   private async getReferralAddress({

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -480,16 +480,12 @@ export class ReferralService {
 
     // If the tx data contains a referral address, then the consumer execution is done,
     // else look for a sticky referral address
-    if (referralAddress) return;
-
-    // if the computation of sticky referral address is configured to be made using a different mechanism or
-    // it is disabled, then stop the execution of the consumer
-    if (this.appConfig.values.stickyReferralAddressesMechanism !== StickyReferralAddressesMechanism.Queue) {
-      return;
-    }
+    if (referralAddress) return { referralAddress, stickyReferralAddress: undefined };
 
     // Compute the sticky referral address
-    await this.getStickyReferralAddress(deposit);
+    const stickyReferralAddress = await this.getStickyReferralAddress(deposit);
+
+    return { referralAddress: undefined, stickyReferralAddress };
   }
 
   public async getStickyReferralAddress(deposit: Deposit) {
@@ -508,6 +504,8 @@ export class ReferralService {
       { id: deposit.id },
       { referralAddress: null, stickyReferralAddress: previousDepositWithReferralAddress?.referralAddress || null },
     );
+
+    return previousDepositWithReferralAddress?.referralAddress;
   }
 
   private async getReferralAddress({

--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -1,6 +1,6 @@
 import { CACHE_MANAGER, Inject, Injectable, Logger } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { DataSource, EntityManager, In, IsNull, LessThanOrEqual, MoreThanOrEqual, Not, Repository } from "typeorm";
+import { DataSource, EntityManager, In, IsNull, LessThanOrEqual, Not, Repository } from "typeorm";
 import BigNumber from "bignumber.js";
 import { performance } from "perf_hooks";
 import Bluebird from "bluebird";

--- a/src/modules/scraper/adapter/messaging/BlockNumberConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/BlockNumberConsumer.ts
@@ -36,6 +36,7 @@ export class BlockNumberConsumer {
     });
     await this.scraperQueuesService.publishMessage<DepositReferralQueueMessage>(ScraperQueue.DepositReferral, {
       depositId: deposit.id,
+      rectifyStickyReferralAddress: true,
     });
     await this.scraperQueuesService.publishMessage<SuggestedFeesQueueMessage>(ScraperQueue.SuggestedFees, {
       depositId: deposit.id,

--- a/src/modules/scraper/adapter/messaging/DepositReferralConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/DepositReferralConsumer.ts
@@ -1,19 +1,57 @@
 import { OnQueueFailed, Process, Processor } from "@nestjs/bull";
 import { Logger } from "@nestjs/common";
 import { Job } from "bull";
-import { DepositReferralQueueMessage, ScraperQueue } from ".";
+import { Repository } from "typeorm";
+import { InjectRepository } from "@nestjs/typeorm";
+
+import { DepositReferralQueueMessage, RectifyStickyReferralQueueMessage, ScraperQueue } from ".";
 import { ReferralService } from "../../../referral/services/service";
+import { Deposit } from "../../../deposit/model/deposit.entity";
+import { EthProvidersService } from "../../../web3/services/EthProvidersService";
+import { ScraperQueuesService } from "../../service/ScraperQueuesService";
 
 @Processor(ScraperQueue.DepositReferral)
 export class DepositReferralConsumer {
   private logger = new Logger(DepositReferralConsumer.name);
 
-  constructor(private referralService: ReferralService) {}
+  constructor(
+    private referralService: ReferralService,
+    @InjectRepository(Deposit) readonly depositRepository: Repository<Deposit>,
+    private ethProvidersService: EthProvidersService,
+    private scraperQueuesService: ScraperQueuesService,
+  ) {}
 
   @Process({ concurrency: 1 })
   private async process(job: Job<DepositReferralQueueMessage>) {
-    const { depositId } = job.data;
-    await this.referralService.extractReferralAddressAndComputeStickyReferralAddresses(depositId);
+    const { depositId, rectifyStickyReferralAddress } = job.data;
+    const deposit = await this.depositRepository.findOne({ where: { id: depositId } });
+
+    if (!deposit) return;
+    // if depositDate field is missing, throw an error to retry the message as this field
+    // is necessary to compute the sticky referral address.
+    if (!deposit.depositDate) throw new Error(`depositId ${deposit.id}: wait for depositDate`);
+
+    const { depositTxHash, sourceChainId } = deposit;
+    const transaction = await this.ethProvidersService.getCachedTransaction(sourceChainId, depositTxHash);
+    const block = await this.ethProvidersService.getCachedBlock(sourceChainId, transaction.blockNumber);
+    const blockTimestamp = parseInt((new Date(block.date).getTime() / 1000).toFixed(0));
+
+    if (!transaction) throw new Error("Transaction not found");
+
+    await this.referralService.extractReferralAddressOrComputeStickyReferralAddresses({
+      blockTimestamp,
+      deposit,
+      transactionData: transaction.data,
+    });
+
+    if (rectifyStickyReferralAddress) {
+      await this.scraperQueuesService.publishMessage<RectifyStickyReferralQueueMessage>(
+        ScraperQueue.RectifyStickyReferral,
+        {
+          depositId: deposit.id,
+        },
+      );
+    }
   }
 
   @OnQueueFailed()

--- a/src/modules/scraper/adapter/messaging/DepositReferralConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/DepositReferralConsumer.ts
@@ -38,13 +38,13 @@ export class DepositReferralConsumer {
 
     if (!transaction) throw new Error("Transaction not found");
 
-    await this.referralService.extractReferralAddressOrComputeStickyReferralAddresses({
+    const { referralAddress } = await this.referralService.extractReferralAddressOrComputeStickyReferralAddresses({
       blockTimestamp,
       deposit,
       transactionData: transaction.data,
     });
 
-    if (rectifyStickyReferralAddress) {
+    if (rectifyStickyReferralAddress && referralAddress) {
       await this.scraperQueuesService.publishMessage<RectifyStickyReferralQueueMessage>(
         ScraperQueue.RectifyStickyReferral,
         {

--- a/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts
@@ -1,0 +1,47 @@
+import { OnQueueFailed, Process, Processor } from "@nestjs/bull";
+import { Logger } from "@nestjs/common";
+import { Job } from "bull";
+import { IsNull, MoreThan, Not, Repository } from "typeorm";
+import { InjectRepository } from "@nestjs/typeorm";
+
+import { DepositReferralQueueMessage, RectifyStickyReferralQueueMessage, ScraperQueue } from ".";
+import { Deposit } from "../../../deposit/model/deposit.entity";
+import { ScraperQueuesService } from "../../service/ScraperQueuesService";
+
+@Processor(ScraperQueue.RectifyStickyReferral)
+export class RectifyStickyReferralConsumer {
+  private logger = new Logger(RectifyStickyReferralConsumer.name);
+
+  constructor(
+    @InjectRepository(Deposit) readonly depositRepository: Repository<Deposit>,
+    private scraperQueuesService: ScraperQueuesService,
+  ) {}
+
+  @Process({ concurrency: 1 })
+  private async process(job: Job<RectifyStickyReferralQueueMessage>) {
+    const { depositId } = job.data;
+    const deposit = await this.depositRepository.findOne({ where: { id: depositId } });
+
+    if (!deposit) return;
+
+    // After extracting the referral address, all deposits with later deposit time must have 
+    // the sticky referral address updated
+    const deposits = await this.depositRepository.find({
+      where: {
+        depositorAddr: deposit.depositorAddr,
+        depositDate: MoreThan(deposit.depositDate),
+      },
+    });
+    for (const d of deposits) {
+      await this.scraperQueuesService.publishMessage<DepositReferralQueueMessage>(ScraperQueue.DepositReferral, {
+        depositId: d.id,
+        rectifyStickyReferralAddress: false,
+      });
+    }
+  }
+
+  @OnQueueFailed()
+  private onQueueFailed(job: Job, error: Error) {
+    this.logger.error(`${ScraperQueue.RectifyStickyReferral} ${JSON.stringify(job.data)} failed: ${error}`);
+  }
+}

--- a/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts
@@ -31,6 +31,9 @@ export class RectifyStickyReferralConsumer {
         depositorAddr: deposit.depositorAddr,
         depositDate: MoreThan(deposit.depositDate),
       },
+      order: {
+        depositDate: "ASC",
+      },
     });
     for (const d of deposits) {
       await this.scraperQueuesService.publishMessage<DepositReferralQueueMessage>(ScraperQueue.DepositReferral, {

--- a/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts
@@ -1,7 +1,7 @@
 import { OnQueueFailed, Process, Processor } from "@nestjs/bull";
 import { Logger } from "@nestjs/common";
 import { Job } from "bull";
-import { IsNull, MoreThan, Not, Repository } from "typeorm";
+import { MoreThan, Repository } from "typeorm";
 import { InjectRepository } from "@nestjs/typeorm";
 
 import { DepositReferralQueueMessage, RectifyStickyReferralQueueMessage, ScraperQueue } from ".";

--- a/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts
@@ -24,7 +24,7 @@ export class RectifyStickyReferralConsumer {
 
     if (!deposit) return;
 
-    // After extracting the referral address, all deposits with later deposit time must have 
+    // After extracting the referral address, all deposits with later deposit time must have
     // the sticky referral address updated
     const deposits = await this.depositRepository.find({
       where: {

--- a/src/modules/scraper/adapter/messaging/index.ts
+++ b/src/modules/scraper/adapter/messaging/index.ts
@@ -6,6 +6,7 @@ export enum ScraperQueue {
   BlockNumber = "BlockNumber",
   TokenDetails = "TokenDetails",
   DepositReferral = "DepositReferral",
+  RectifyStickyReferral = "RectifyStickyReferral",
   TokenPrice = "TokenPrice",
   DepositFilledDate = "DepositFilledDate",
   MerkleDistributorBlocksEvents = "MerkleDistributorBlocksEvents",
@@ -69,6 +70,11 @@ export type TokenDetailsQueueMessage = {
 };
 
 export type DepositReferralQueueMessage = {
+  depositId: number;
+  rectifyStickyReferralAddress: boolean;
+};
+
+export type RectifyStickyReferralQueueMessage = {
   depositId: number;
 };
 

--- a/src/modules/scraper/entry-point/http/controller.ts
+++ b/src/modules/scraper/entry-point/http/controller.ts
@@ -27,6 +27,7 @@ import {
   SubmitSuggestedFeesBody,
   RetryFailedJobsBody,
   RetryIncompleteDepositsBody,
+  SubmitReindexReferralAddressJobBody,
 } from "./dto";
 
 @Controller()
@@ -119,6 +120,15 @@ export class ScraperController {
         depositId,
       });
     }
+  }
+
+  @Post("scraper/referral-address-reindex")
+  @Roles(Role.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiTags("scraper")
+  async submitReindexReferralAddressJob(@Body() body: SubmitReindexReferralAddressJobBody) {
+    await this.scraperService.reindexReferralAddress(body);
   }
 
   @Post("scraper/deposit-filled-date")

--- a/src/modules/scraper/entry-point/http/controller.ts
+++ b/src/modules/scraper/entry-point/http/controller.ts
@@ -118,6 +118,7 @@ export class ScraperController {
     for (let depositId = fromDepositId; depositId <= toDepositId; depositId++) {
       await this.scraperQueuesService.publishMessage<DepositReferralQueueMessage>(ScraperQueue.DepositReferral, {
         depositId,
+        rectifyStickyReferralAddress: true,
       });
     }
   }

--- a/src/modules/scraper/entry-point/http/dto.ts
+++ b/src/modules/scraper/entry-point/http/dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsIn, IsInt, IsOptional, IsString } from "class-validator";
+import { IsDateString, IsIn, IsInt, IsOptional, IsString } from "class-validator";
 import { ScraperQueue } from "../../adapter/messaging";
 
 export class ProcessBlocksBody {
@@ -34,6 +34,16 @@ export class SubmitReferralAddressJobBody {
   @IsInt()
   @ApiProperty({ example: 2 })
   toDepositId: number;
+}
+
+export class SubmitReindexReferralAddressJobBody {
+  @IsDateString()
+  @ApiProperty({ example: "2022-11-08T11:00:00.000Z", required: true })
+  fromDate: string;
+
+  @IsDateString()
+  @ApiProperty({ example: "2022-11-08T11:00:00.000Z", required: true })
+  toDate: string;
 }
 
 export class SubmitDepositFilledDateBody {

--- a/src/modules/scraper/module.ts
+++ b/src/modules/scraper/module.ts
@@ -31,10 +31,11 @@ import { SuggestedFeesConsumer } from "./adapter/messaging/SuggestedFeesConsumer
 import { SuggestedFeesService } from "./adapter/across-serverless-api/suggested-fees-service";
 import { TrackFillEventConsumer } from "./adapter/messaging/TrackFillEventConsumer";
 import { TrackService } from "./adapter/amplitude/track-service";
-import { ModuleOptions, RunMode } from "../../dynamic-module";
+import { ModuleOptions } from "../../dynamic-module";
 import { DepositModule } from "../deposit/module";
 import { AirdropModule } from "../airdrop/module";
 import { RefundRequestedEv } from "../web3/model/refund-requested-ev.entity";
+import { RectifyStickyReferralConsumer } from "./adapter/messaging/RectifyStickyReferralConsumer";
 
 @Module({})
 export class ScraperModule {
@@ -57,6 +58,7 @@ export class ScraperModule {
       DepositAcxPriceConsumer,
       SuggestedFeesConsumer,
       TrackFillEventConsumer,
+      RectifyStickyReferralConsumer,
     ];
 
     return {
@@ -136,6 +138,9 @@ export class ScraperModule {
         }),
         BullModule.registerQueue({
           name: ScraperQueue.TrackFillEvent,
+        }),
+        BullModule.registerQueue({
+          name: ScraperQueue.RectifyStickyReferral,
         }),
       ],
       exports: [ScraperQueuesService],

--- a/src/modules/scraper/service.ts
+++ b/src/modules/scraper/service.ts
@@ -11,11 +11,12 @@ import { ScraperQueuesService } from "./service/ScraperQueuesService";
 import {
   BlockNumberQueueMessage,
   BlocksEventsQueueMessage,
+  DepositReferralQueueMessage,
   MerkleDistributorBlocksEventsQueueMessage,
   ScraperQueue,
 } from "./adapter/messaging";
 import { wait } from "../../utils";
-import { RetryIncompleteDepositsBody } from "./entry-point/http/dto";
+import { RetryIncompleteDepositsBody, SubmitReindexReferralAddressJobBody } from "./entry-point/http/dto";
 import { Deposit } from "../deposit/model/deposit.entity";
 
 @Injectable()
@@ -213,6 +214,38 @@ export class ScraperService {
       await this.scraperQueuesService.publishMessage<BlockNumberQueueMessage>(ScraperQueue.BlockNumber, {
         depositId: deposit.id,
       });
+    }
+  }
+
+  public async reindexReferralAddress(data: SubmitReindexReferralAddressJobBody) {
+    const { fromDate, toDate } = data;
+    let page = 0;
+    const limit = 1000;
+    while (true) {
+      // Make paginated SQL queries to get all deposits without a referral address and made after the processed deposit
+      const deposits = await this.depositRepository
+        .createQueryBuilder("d")
+        .where("d.depositDate >= :fromDate", { fromDate })
+        .andWhere("d.depositDate <= :toDate", { toDate })
+        .orderBy("d.depositDate", "ASC")
+        .addOrderBy("d.id", "ASC")
+        .take(limit)
+        .skip(page * limit)
+        .getMany();
+
+      const messages = deposits.map((d) => ({ depositId: d.id }));
+      await this.scraperQueuesService.publishMessagesBulk<DepositReferralQueueMessage>(
+        ScraperQueue.DepositReferral,
+        messages,
+      );
+
+      // if the length of the returned deposits is lower than the limit, we processed all depositor's deposits,
+      // else go to the next page
+      if (deposits.length < limit) {
+        break;
+      } else {
+        page = page + 1;
+      }
     }
   }
 }

--- a/src/modules/scraper/service.ts
+++ b/src/modules/scraper/service.ts
@@ -233,7 +233,10 @@ export class ScraperService {
         .skip(page * limit)
         .getMany();
 
-      const messages = deposits.map((d) => ({ depositId: d.id }));
+      const messages: DepositReferralQueueMessage[] = deposits.map((d) => ({
+        depositId: d.id,
+        rectifyStickyReferralAddress: false,
+      }));
       await this.scraperQueuesService.publishMessagesBulk<DepositReferralQueueMessage>(
         ScraperQueue.DepositReferral,
         messages,

--- a/src/modules/scraper/service/ScraperQueuesService.ts
+++ b/src/modules/scraper/service/ScraperQueuesService.ts
@@ -23,6 +23,7 @@ export class ScraperQueuesService {
     @InjectQueue(ScraperQueue.DepositAcxPrice) private depositAcxPriceQueue: Queue,
     @InjectQueue(ScraperQueue.SuggestedFees) private suggestedFeesQueue: Queue,
     @InjectQueue(ScraperQueue.TrackFillEvent) private trackFillEventsQueue: Queue,
+    @InjectQueue(ScraperQueue.RectifyStickyReferral) private rectifyStickyReferralQueue: Queue,
   ) {
     this.queuesMap = {
       [ScraperQueue.BlocksEvents]: this.blocksEventsQueue,
@@ -38,6 +39,7 @@ export class ScraperQueuesService {
       [ScraperQueue.DepositAcxPrice]: this.depositAcxPriceQueue,
       [ScraperQueue.SuggestedFees]: this.suggestedFeesQueue,
       [ScraperQueue.TrackFillEvent]: this.trackFillEventsQueue,
+      [ScraperQueue.RectifyStickyReferral]: this.rectifyStickyReferralQueue,
     };
     this.initLogs();
   }

--- a/test/sticky-referral-address.e2e-spec.ts
+++ b/test/sticky-referral-address.e2e-spec.ts
@@ -102,7 +102,7 @@ describe("Sticky referral address", () => {
       },
     ]);
     await referralService.getStickyReferralAddress(deposits[1]);
-    await referralService.getStickyReferralAddress(deposits[0]);
+    await referralService.getStickyReferralAddress(deposits[2]);
     let d = await referralService.depositRepository.findOne({ where: { id: deposits[0].id } });
     expect(d.referralAddress).toEqual("B");
     expect(d.stickyReferralAddress).toEqual("B");
@@ -137,9 +137,7 @@ describe("Sticky referral address", () => {
         depositDate: new Date("2023-09-04"),
       },
     ]);
-    await referralService.getStickyReferralAddress(deposits[0]);
     await referralService.getStickyReferralAddress(deposits[1]);
-    await referralService.getStickyReferralAddress(deposits[2]);
     await referralService.getStickyReferralAddress(deposits[3]);
 
     let d = await referralService.depositRepository.findOne({ where: { id: deposits[0].id } });

--- a/test/sticky-referral-address.e2e-spec.ts
+++ b/test/sticky-referral-address.e2e-spec.ts
@@ -46,7 +46,7 @@ describe("Sticky referral address", () => {
         depositDate: new Date("2023-09-02"),
       },
     ]);
-    await referralService.computeStickyReferralAddress(deposits[1]);
+    await referralService.getStickyReferralAddress(deposits[1]);
     let d = await referralService.depositRepository.findOne({ where: { id: deposits[0].id } });
     expect(d.referralAddress).toEqual("B");
     expect(d.stickyReferralAddress).toEqual("B");
@@ -72,7 +72,7 @@ describe("Sticky referral address", () => {
         depositDate: new Date("2023-09-03"),
       },
     ]);
-    await referralService.computeStickyReferralAddress(deposits[1]);
+    await referralService.getStickyReferralAddress(deposits[1]);
     let d = await referralService.depositRepository.findOne({ where: { id: deposits[0].id } });
     expect(d.referralAddress).toEqual("B");
     expect(d.stickyReferralAddress).toEqual("B");
@@ -101,8 +101,8 @@ describe("Sticky referral address", () => {
         depositDate: new Date("2023-09-04"),
       },
     ]);
-    await referralService.computeStickyReferralAddress(deposits[1]);
-    await referralService.computeStickyReferralAddress(deposits[0]);
+    await referralService.getStickyReferralAddress(deposits[1]);
+    await referralService.getStickyReferralAddress(deposits[0]);
     let d = await referralService.depositRepository.findOne({ where: { id: deposits[0].id } });
     expect(d.referralAddress).toEqual("B");
     expect(d.stickyReferralAddress).toEqual("B");
@@ -137,10 +137,10 @@ describe("Sticky referral address", () => {
         depositDate: new Date("2023-09-04"),
       },
     ]);
-    await referralService.computeStickyReferralAddress(deposits[0]);
-    await referralService.computeStickyReferralAddress(deposits[1]);
-    await referralService.computeStickyReferralAddress(deposits[2]);
-    await referralService.computeStickyReferralAddress(deposits[3]);
+    await referralService.getStickyReferralAddress(deposits[0]);
+    await referralService.getStickyReferralAddress(deposits[1]);
+    await referralService.getStickyReferralAddress(deposits[2]);
+    await referralService.getStickyReferralAddress(deposits[3]);
 
     let d = await referralService.depositRepository.findOne({ where: { id: deposits[0].id } });
     expect(d.referralAddress).toEqual("B");


### PR DESCRIPTION
This is a refactoring of the mechanism used for extracting the referral address and computing the sticky referral address

**How it works**
1. A message containing a `depositId` is submitted on the `DepositReferral` queue and it is processed by [DepositReferralConsumer](https://github.com/across-protocol/scraper-api/blob/9d7e48c26723c680e58a0719c698d337fce03fcf/src/modules/scraper/adapter/messaging/DepositReferralConsumer.ts#L25-L55). This consumer has only 1 job: it extracts the referral address from the tx data or it derives the sticky referral address from previous deposits made by the same depositor
2. The consumer from above also publishes a message on the `RectifyStickyReferral` queue and the message is processed by [RectifyStickyReferralConsumer](https://github.com/across-protocol/scraper-api/blob/9d7e48c26723c680e58a0719c698d337fce03fcf/src/modules/scraper/adapter/messaging/RectifyStickyReferralConsumer.ts#L21-L41). If there are deposits in the DB with a sticky referral address, but an earlier deposit with a referral address is inserted in the DB at a later time, then the sticky referral address needs to be recomputed. This is achieved by detecting such deposits and re-publish then on the `DepositReferral` queue

**New API endpoints**

There is a new admin [endpoint](https://github.com/across-protocol/scraper-api/pull/284/files#diff-6584665fe6b6350a2fbd5484d734bd1ff0cf61d68dab6699a06c4f8e16fa95d4R126-R134) `POST /scraper/referral-address-reindex` which [publishes](https://github.com/across-protocol/scraper-api/pull/284/files#diff-bb8f574ca10ada36c4348f8454670dbfb452ba295bfafe7e0ca187b893590a8bR219-R253) all the deposits within a particular date range to the `DepositReferral` queue (step 1 from above). This endpoint is necessary because we need to recompute all the sticky referral addresses for October because of a bug that caused the sticky referral address to be computed incorrectly for a few deposits