### PR TITLE
feat: include rewards to /deposits/tx-page response

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -45,8 +45,8 @@ export class AppModule {
       AuthModule.forRoot(moduleOptions),
       UserModule.forRoot(moduleOptions),
       AirdropModule.forRoot(moduleOptions),
+      RewardModule.forRoot(moduleOptions),
       CacheModule.register({ isGlobal: true }),
-      RewardModule,
     ];
 
     if (moduleOptions.runModes.includes(RunMode.Scraper)) {

--- a/src/modules/deposit/entry-point/http/dto.ts
+++ b/src/modules/deposit/entry-point/http/dto.ts
@@ -97,7 +97,7 @@ export class GetPendingDepositsQuery {
   offset: string;
 }
 
-export class GetDepositsV2Query {
+export class GetDepositsBaseQuery {
   @IsOptional()
   @IsEnum(
     {
@@ -110,18 +110,6 @@ export class GetDepositsV2Query {
   )
   @ApiProperty({ example: "filled", required: false })
   status: "filled" | "pending";
-
-  @IsOptional()
-  @IsArray()
-  @IsEnum(
-    {
-      TOKEN: "token",
-    },
-    { each: true, message: "Must be one of: 'token'" },
-  )
-  @ArrayMaxSize(1)
-  @ApiProperty({ example: ["token"], required: false })
-  include: Array<"token">;
 
   @IsOptional()
   @IsInt()
@@ -188,7 +176,21 @@ export class GetDepositsV2Query {
   endDepositDate: string;
 }
 
-export class GetDepositsForTxPageQuery extends GetDepositsV2Query {
+export class GetDepositsV2Query extends GetDepositsBaseQuery {
+  @IsOptional()
+  @IsArray()
+  @IsEnum(
+    {
+      TOKEN: "token",
+    },
+    { each: true, message: "Must be one of: 'token'" },
+  )
+  @ArrayMaxSize(1)
+  @ApiProperty({ example: ["token"], required: false })
+  include: Array<"token">;
+}
+
+export class GetDepositsForTxPageQuery extends GetDepositsBaseQuery {
   @IsOptional()
   @IsBoolean()
   @Type(() => Boolean)
@@ -206,4 +208,17 @@ export class GetDepositsForTxPageQuery extends GetDepositsV2Query {
   )
   @ApiProperty({ example: "status", required: false })
   orderBy: "status";
+
+  @IsOptional()
+  @IsArray()
+  @IsEnum(
+    {
+      TOKEN: "token",
+      REWARDS: "rewards",
+    },
+    { each: true, message: "Must be one of: 'token', 'rewards'" },
+  )
+  @ArrayMaxSize(1)
+  @ApiProperty({ example: ["token"], required: false })
+  include: Array<"token" | "rewards">;
 }

--- a/src/modules/deposit/entry-point/http/dto.ts
+++ b/src/modules/deposit/entry-point/http/dto.ts
@@ -174,9 +174,7 @@ export class GetDepositsBaseQuery {
   @Type(() => String)
   @ApiProperty({ example: "2022-11-08T11:00:00.000Z", required: false })
   endDepositDate: string;
-}
 
-export class GetDepositsV2Query extends GetDepositsBaseQuery {
   @IsOptional()
   @IsArray()
   @IsEnum(
@@ -189,6 +187,8 @@ export class GetDepositsV2Query extends GetDepositsBaseQuery {
   @ApiProperty({ example: ["token"], required: false })
   include: Array<"token">;
 }
+
+export class GetDepositsV2Query extends GetDepositsBaseQuery {}
 
 export class GetDepositsForTxPageQuery extends GetDepositsBaseQuery {
   @IsOptional()
@@ -208,17 +208,4 @@ export class GetDepositsForTxPageQuery extends GetDepositsBaseQuery {
   )
   @ApiProperty({ example: "status", required: false })
   orderBy: "status";
-
-  @IsOptional()
-  @IsArray()
-  @IsEnum(
-    {
-      TOKEN: "token",
-      REWARDS: "rewards",
-    },
-    { each: true, message: "Must be one of: 'token', 'rewards'" },
-  )
-  @ArrayMaxSize(1)
-  @ApiProperty({ example: ["token"], required: false })
-  include: Array<"token" | "rewards">;
 }

--- a/src/modules/deposit/model/DepositsMv.entity.ts
+++ b/src/modules/deposit/model/DepositsMv.entity.ts
@@ -108,3 +108,7 @@ export class DepositsMv {
   @ViewColumn()
   acxUsdPrice: string;
 }
+
+export class DepositsMvWithRewards extends DepositsMv {
+  acxRewards: string;
+}

--- a/src/modules/deposit/module.ts
+++ b/src/modules/deposit/module.ts
@@ -7,6 +7,8 @@ import { DepositController } from "./entry-point/http/controller";
 import { DepositService } from "./service";
 import { DepositFixture } from "./adapter/db/deposit-fixture";
 import { EtlController } from "./entry-point/http/etl-controller";
+import { RewardModule } from "../rewards/module";
+import { Reward } from "../rewards/model/reward.entity";
 
 @Module({})
 export class DepositModule {
@@ -19,7 +21,12 @@ export class DepositModule {
         controllers: [...module.controllers, DepositController, EtlController],
         providers: [...module.providers, DepositService],
         exports: [...module.exports, DepositService],
-        imports: [...module.imports, TypeOrmModule.forFeature([Deposit]), AppConfigModule],
+        imports: [
+          ...module.imports,
+          TypeOrmModule.forFeature([Deposit, Reward]),
+          AppConfigModule,
+          RewardModule.forRoot(moduleOptions),
+        ],
       };
     }
 

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -91,7 +91,7 @@ export class DepositService {
     const [deposits, total] = await queryBuilder.getManyAndCount();
 
     // Only include rewards if a user address is provided
-    if (query.include && query.depositorOrRecipientAddress && query.include.includes("rewards")) {
+    if (query.include && query.depositorOrRecipientAddress) {
       const userAddress = this.assertValidAddress(query.depositorOrRecipientAddress);
       const rewards = await this.rewardService.getRewardsForDepositsAndUserAddress(deposits, userAddress);
       const enrichedDeposits = this.rewardService.enrichDepositsWithRewards(deposits, rewards);

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -1,9 +1,9 @@
-import { DateTime } from "luxon";
 import { CACHE_MANAGER, Inject, Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Brackets, DataSource, Repository } from "typeorm";
 import { utils } from "ethers";
 import { Cache } from "cache-manager";
+
 import { Deposit } from "./model/deposit.entity";
 import {
   getAvgFillTimeQuery,
@@ -13,7 +13,9 @@ import {
 } from "./adapter/db/queries";
 import { AppConfig } from "../configuration/configuration.service";
 import { InvalidAddressException, DepositNotFoundException } from "./exceptions";
-import { GetDepositsV2Query, GetDepositsForTxPageQuery } from "./entry-point/http/dto";
+import { GetDepositsV2Query, GetDepositsForTxPageQuery, GetDepositsBaseQuery } from "./entry-point/http/dto";
+import { formatDeposit } from "./utils";
+import { RewardService } from "../rewards/services/reward-service";
 
 export const DEPOSITS_STATS_CACHE_KEY = "deposits:stats";
 
@@ -24,6 +26,7 @@ export class DepositService {
     @InjectRepository(Deposit) private depositRepository: Repository<Deposit>,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private dataSource: DataSource,
+    private rewardService: RewardService,
   ) {}
 
   public async getCachedGeneralStats() {
@@ -51,6 +54,7 @@ export class DepositService {
 
     let queryBuilder = this.depositRepository.createQueryBuilder("d");
     queryBuilder = this.getFilteredDepositsQuery(queryBuilder, query);
+    queryBuilder = this.getJoinedDepositsQuery(queryBuilder, query);
 
     // If this flag is set to true, we will skip pending deposits that:
     // - are older than 1 day because the relayer will ignore such deposits using its fixed lookback
@@ -85,6 +89,26 @@ export class DepositService {
     queryBuilder = queryBuilder.skip(offset);
 
     const [deposits, total] = await queryBuilder.getManyAndCount();
+
+    // Only include rewards if a user address is provided
+    if (query.include && query.depositorOrRecipientAddress && query.include.includes("rewards")) {
+      const userAddress = this.assertValidAddress(query.depositorOrRecipientAddress);
+      const rewards = await this.rewardService.getRewardsForDepositsAndUserAddress(deposits, userAddress);
+      const enrichedDeposits = this.rewardService.enrichDepositsWithRewards(deposits, rewards);
+      return {
+        deposits: enrichedDeposits.map(({ deposit, rewards }) => {
+          return {
+            ...formatDeposit(deposit),
+            rewards,
+          };
+        }),
+        pagination: {
+          limit,
+          offset,
+          total,
+        },
+      };
+    }
 
     return {
       deposits: deposits.map(formatDeposit),
@@ -261,7 +285,7 @@ export class DepositService {
 
   private getFilteredDepositsQuery(
     queryBuilder: ReturnType<typeof this.depositRepository.createQueryBuilder>,
-    filter: Partial<GetDepositsV2Query>,
+    filter: Partial<GetDepositsBaseQuery>,
   ) {
     queryBuilder = queryBuilder.andWhere("d.depositDate is not null");
 
@@ -321,7 +345,7 @@ export class DepositService {
 
   private getJoinedDepositsQuery(
     queryBuilder: ReturnType<typeof this.depositRepository.createQueryBuilder>,
-    filter: Partial<GetDepositsV2Query>,
+    filter: Partial<GetDepositsV2Query | GetDepositsForTxPageQuery>,
   ) {
     if (!filter.include) {
       return queryBuilder;
@@ -342,43 +366,4 @@ export class DepositService {
       throw new InvalidAddressException();
     }
   }
-}
-
-/**
- * Format deposit to entity to match `Transfer` structure from sdk.
- * @param deposit - Deposit entity from db.
- * @returns Formatted deposit entity that matches `Transfer` struct.
- */
-export function formatDeposit(deposit: Deposit) {
-  return {
-    depositId: deposit.depositId,
-    depositTime: Math.round(DateTime.fromISO(deposit.depositDate.toISOString()).toSeconds()),
-    fillTime: deposit.filledDate
-      ? Math.round(DateTime.fromISO(deposit.filledDate.toISOString()).toSeconds())
-      : undefined,
-    status: deposit.status,
-    filled: deposit.filled,
-    sourceChainId: deposit.sourceChainId,
-    destinationChainId: deposit.destinationChainId,
-    assetAddr: deposit.tokenAddr,
-    token: deposit.token
-      ? {
-          address: deposit.token.address,
-          symbol: deposit.token.symbol,
-          decimals: deposit.token.decimals,
-          chainId: deposit.token.chainId,
-        }
-      : undefined,
-    depositorAddr: deposit.depositorAddr,
-    recipientAddr: deposit.recipientAddr,
-    message: deposit.message,
-    amount: deposit.amount,
-    depositTxHash: deposit.depositTxHash,
-    fillTxs: deposit.fillTxs.map(({ hash }) => hash),
-    speedUps: deposit.speedUps,
-    depositRelayerFeePct: deposit.depositRelayerFeePct,
-    initialRelayerFeePct: deposit.initialRelayerFeePct,
-    suggestedRelayerFeePct: deposit.suggestedRelayerFeePct,
-    feeBreakdown: deposit.feeBreakdown,
-  };
 }

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -91,7 +91,7 @@ export class DepositService {
     const [deposits, total] = await queryBuilder.getManyAndCount();
 
     // Only include rewards if a user address is provided
-    if (query.include && query.depositorOrRecipientAddress) {
+    if (query.depositorOrRecipientAddress) {
       const userAddress = this.assertValidAddress(query.depositorOrRecipientAddress);
       const rewards = await this.rewardService.getRewardsForDepositsAndUserAddress(deposits, userAddress);
       const enrichedDeposits = this.rewardService.enrichDepositsWithRewards(deposits, rewards);

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -94,7 +94,7 @@ export class DepositService {
     if (query.depositorOrRecipientAddress) {
       const userAddress = this.assertValidAddress(query.depositorOrRecipientAddress);
       const rewards = await this.rewardService.getRewardsForDepositsAndUserAddress(deposits, userAddress);
-      const enrichedDeposits = this.rewardService.enrichDepositsWithRewards(deposits, rewards);
+      const enrichedDeposits = this.rewardService.enrichDepositsWithRewards(userAddress, deposits, rewards);
       return {
         deposits: enrichedDeposits.map(({ deposit, rewards }) => {
           return {

--- a/src/modules/deposit/utils.ts
+++ b/src/modules/deposit/utils.ts
@@ -1,0 +1,35 @@
+import { DateTime } from "luxon";
+
+import { Deposit } from "./model/deposit.entity";
+
+/**
+ * Format deposit to entity to match `Transfer` structure from sdk.
+ * @param deposit - Deposit entity from db.
+ * @returns Formatted deposit entity that matches `Transfer` struct.
+ */
+export function formatDeposit(deposit: Deposit) {
+  return {
+    depositId: deposit.depositId,
+    depositTime: Math.round(DateTime.fromISO(deposit.depositDate.toISOString()).toSeconds()),
+    fillTime: deposit.filledDate
+      ? Math.round(DateTime.fromISO(deposit.filledDate.toISOString()).toSeconds())
+      : undefined,
+    status: deposit.status,
+    filled: deposit.filled,
+    sourceChainId: deposit.sourceChainId,
+    destinationChainId: deposit.destinationChainId,
+    assetAddr: deposit.tokenAddr,
+    assetSymbol: deposit.token?.symbol,
+    depositorAddr: deposit.depositorAddr,
+    recipientAddr: deposit.recipientAddr,
+    message: deposit.message,
+    amount: deposit.amount,
+    depositTxHash: deposit.depositTxHash,
+    fillTxs: deposit.fillTxs.map(({ hash }) => hash),
+    speedUps: deposit.speedUps,
+    depositRelayerFeePct: deposit.depositRelayerFeePct,
+    initialRelayerFeePct: deposit.initialRelayerFeePct,
+    suggestedRelayerFeePct: deposit.suggestedRelayerFeePct,
+    feeBreakdown: deposit.feeBreakdown,
+  };
+}

--- a/src/modules/deposit/utils.ts
+++ b/src/modules/deposit/utils.ts
@@ -35,6 +35,7 @@ export function formatDeposit(deposit: Deposit) {
           address: deposit.token.address,
           chainId: deposit.token.chainId,
           symbol: deposit.token.symbol,
+          decimals: deposit.token.decimals,
         }
       : undefined,
   };

--- a/src/modules/deposit/utils.ts
+++ b/src/modules/deposit/utils.ts
@@ -19,7 +19,6 @@ export function formatDeposit(deposit: Deposit) {
     sourceChainId: deposit.sourceChainId,
     destinationChainId: deposit.destinationChainId,
     assetAddr: deposit.tokenAddr,
-    assetSymbol: deposit.token?.symbol,
     depositorAddr: deposit.depositorAddr,
     recipientAddr: deposit.recipientAddr,
     message: deposit.message,
@@ -31,5 +30,12 @@ export function formatDeposit(deposit: Deposit) {
     initialRelayerFeePct: deposit.initialRelayerFeePct,
     suggestedRelayerFeePct: deposit.suggestedRelayerFeePct,
     feeBreakdown: deposit.feeBreakdown,
+    token: deposit.token
+      ? {
+          address: deposit.token.address,
+          chainId: deposit.token.chainId,
+          symbol: deposit.token.symbol,
+        }
+      : undefined,
   };
 }

--- a/src/modules/referral/services/queries.ts
+++ b/src/modules/referral/services/queries.ts
@@ -18,6 +18,22 @@ export const getReferralsQuery = () => {
   `;
 };
 
+export const getReferralsByDepositIdsQuery = () => {
+  return `
+    select
+      *,
+      case
+        when d."depositorAddr" = $1 and d."referralAddress" = $1
+          then trunc(cast(d."bridgeFeeUsd" * d."referralRate" / d."acxUsdPrice" * power(10, 18) * d.multiplier as decimal))
+        when d."depositorAddr" = $1
+        then trunc(cast(d."bridgeFeeUsd" * d."referralRate" / d."acxUsdPrice" * 0.25 * power(10, 18) * d.multiplier as decimal))
+        else trunc(cast(d."bridgeFeeUsd" * d."referralRate" / d."acxUsdPrice" * 0.75 * power(10, 18) * d.multiplier as decimal))
+      end as "acxRewards"
+    from deposits_mv as d
+    where d.id = ANY($2);
+  `;
+};
+
 export const getReferralsTotalQuery = () => {
   return `
     select count(*)

--- a/src/modules/rewards/adapter/db/reward-fixture.ts
+++ b/src/modules/rewards/adapter/db/reward-fixture.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { Reward, RewardMetadata, RewardType } from "../../model/reward.entity";
+import { getRandomInt } from "../../../../utils";
+
+@Injectable()
+export class RewardFixture {
+  public constructor(@InjectRepository(Reward) private rewardRepository: Repository<Reward>) {}
+
+  public insertReward(rewardArgs: Partial<Reward>) {
+    const reward = this.rewardRepository.create(mockRewardEntity(rewardArgs));
+    return this.rewardRepository.save(reward);
+  }
+
+  public deleteAllRewards() {
+    return this.rewardRepository.query(`truncate table "reward" restart identity cascade`);
+  }
+}
+
+export function mockRewardEntity(overrides: Partial<Reward>) {
+  return {
+    depositPrimaryKey: getRandomInt(),
+    recipient: "0x",
+    type: "op-rebates" as RewardType,
+    metadata: { type: "op-rebates", rate: 0.95 } as RewardMetadata,
+    amount: "1000000000000000000",
+    amountUsd: "1",
+    rewardTokenId: 1,
+    rewardTokenPriceId: 1,
+    ...overrides,
+  };
+}

--- a/src/modules/rewards/module.ts
+++ b/src/modules/rewards/module.ts
@@ -7,18 +7,43 @@ import { Web3Module } from "../web3/module";
 
 import { RewardController } from "./entrypoints/http/controller";
 import { OpRebateService } from "./services/op-rebate-service";
+import { RewardService } from "./services/reward-service";
+import { ReferralService } from "../referral/services/service";
+import { ReferralModule } from "../referral/module";
 import { Reward } from "./model/reward.entity";
+import { DepositsMv } from "../deposit/model/DepositsMv.entity";
+import { ReferralRewardsWindowJob } from "../referral/model/ReferralRewardsWindowJob.entity";
+import { ReferralRewardsWindowJobResult } from "../referral/model/ReferralRewardsWindowJobResult.entity";
+import { MarketPriceModule } from "../market-price/module";
+import { ModuleOptions, RunMode } from "../../dynamic-module";
+import { RewardFixture } from "./adapter/db/reward-fixture";
 
 @Module({})
 export class RewardModule {
-  static forRoot(): DynamicModule {
+  static forRoot(moduleOptions: ModuleOptions): DynamicModule {
     const module: DynamicModule = {
       module: RewardModule,
       controllers: [RewardController],
-      providers: [OpRebateService],
-      imports: [TypeOrmModule.forFeature([Deposit, Reward]), AppConfigModule, Web3Module],
-      exports: [OpRebateService],
+      providers: [RewardService, OpRebateService, ReferralService],
+      imports: [
+        TypeOrmModule.forFeature([
+          Deposit,
+          Reward,
+          DepositsMv,
+          ReferralRewardsWindowJob,
+          ReferralRewardsWindowJobResult,
+        ]),
+        AppConfigModule,
+        Web3Module,
+        ReferralModule.forRoot(moduleOptions),
+        MarketPriceModule.forRoot(moduleOptions),
+      ],
+      exports: [RewardService, OpRebateService, ReferralService],
     };
+
+    if (moduleOptions.runModes.includes(RunMode.Test)) {
+      module.providers = [...module.providers, RewardFixture];
+    }
 
     return module;
   }

--- a/src/modules/rewards/services/op-rebate-service.ts
+++ b/src/modules/rewards/services/op-rebate-service.ts
@@ -27,6 +27,16 @@ export class OpRebateService {
     private appConfig: AppConfig,
   ) {}
 
+  public async getOpRebateRewardsForDepositPrimaryKeys(depositPrimaryKeys: number[]) {
+    const rewardsQuery = this.rewardRepository
+      .createQueryBuilder("r")
+      .where("r.type = :type", { type: "op-rebates" })
+      .andWhere("r.depositPrimaryKey IN (:...depositPrimaryKeys)", { depositPrimaryKeys })
+      .leftJoinAndSelect("r.rewardToken", "rewardToken");
+    const rewards = await rewardsQuery.getMany();
+    return rewards;
+  }
+
   public async createOpRebatesForDeposit(depositPrimaryKey: number) {
     if (!this.appConfig.values.rewardPrograms["op-rebates"].enabled) {
       this.logger.verbose(`OP rebate rewards are disabled. Skipping...`);

--- a/src/modules/rewards/services/reward-service.ts
+++ b/src/modules/rewards/services/reward-service.ts
@@ -47,6 +47,8 @@ export class RewardService {
 
       return {
         deposit,
+        // We assume that a deposit can only have one type of reward here. If this changes in the future for
+        // other types of rewards, we will need to change this logic.
         rewards: opRebate ? this.formatOpRebate(opRebate) : referral ? this.formatReferral(referral) : undefined,
       };
     });

--- a/src/modules/rewards/services/reward-service.ts
+++ b/src/modules/rewards/services/reward-service.ts
@@ -5,13 +5,11 @@ import BigNumber from "bignumber.js";
 import { ethers } from "ethers";
 
 import { Deposit } from "../../deposit/model/deposit.entity";
-import { DepositsMv } from "../../deposit/model/DepositsMv.entity";
+import { DepositsMvWithRewards } from "../../deposit/model/DepositsMv.entity";
 import { ReferralService } from "../../referral/services/service";
 
 import { OpRebateService } from "./op-rebate-service";
 import { Reward } from "../model/reward.entity";
-
-type Referral = DepositsMv & { appliedRate: number; acxRewards: string };
 
 @Injectable()
 export class RewardService {
@@ -35,10 +33,11 @@ export class RewardService {
   }
 
   public enrichDepositsWithRewards(
+    userAddress: string,
     deposits: Deposit[],
     rewards: {
       "op-rebates": Reward[];
-      referrals: Referral[];
+      referrals: DepositsMvWithRewards[];
     },
   ) {
     return deposits.map((deposit) => {
@@ -49,7 +48,11 @@ export class RewardService {
         deposit,
         // We assume that a deposit can only have one type of reward here. If this changes in the future for
         // other types of rewards, we will need to change this logic.
-        rewards: opRebate ? this.formatOpRebate(opRebate) : referral ? this.formatReferral(referral) : undefined,
+        rewards: opRebate
+          ? this.formatOpRebate(opRebate)
+          : referral
+          ? this.formatReferral(referral, userAddress)
+          : undefined,
       };
     });
   }
@@ -63,11 +66,18 @@ export class RewardService {
     };
   }
 
-  public formatReferral(referral: Referral) {
+  public formatReferral(referral: DepositsMvWithRewards, userAddress: string) {
+    const userRate =
+      referral.depositorAddr === userAddress && referral.referralAddress === userAddress
+        ? 1
+        : referral.depositorAddr === userAddress
+        ? 0.25
+        : 0.75;
     return {
       type: "referrals",
       tier: this.referralService.getTierLevelByRate(referral.referralRate),
-      rate: referral.appliedRate,
+      rate: userRate * referral.referralRate * referral.multiplier,
+      userRate,
       referralRate: referral.referralRate,
       multiplier: referral.multiplier,
       amount: referral.acxRewards,

--- a/src/modules/rewards/services/reward-service.ts
+++ b/src/modules/rewards/services/reward-service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import BigNumber from "bignumber.js";
+import { ethers } from "ethers";
+
+import { Deposit } from "../../deposit/model/deposit.entity";
+import { DepositsMv } from "../../deposit/model/DepositsMv.entity";
+import { ReferralService } from "../../referral/services/service";
+
+import { OpRebateService } from "./op-rebate-service";
+import { Reward } from "../model/reward.entity";
+
+type Referral = DepositsMv & { appliedRate: number; acxRewards: string };
+
+@Injectable()
+export class RewardService {
+  constructor(
+    @InjectRepository(Deposit) readonly depositRepository: Repository<Deposit>,
+    @InjectRepository(Reward) readonly rewardRepository: Repository<Reward>,
+    private referralService: ReferralService,
+    private opRebateService: OpRebateService,
+  ) {}
+
+  public async getRewardsForDepositsAndUserAddress(deposits: Deposit[], userAddress: string) {
+    const depositPrimaryKeys = deposits.map((deposit) => deposit.id);
+    const [opRebateRewards, referralRewards] = await Promise.all([
+      this.opRebateService.getOpRebateRewardsForDepositPrimaryKeys(depositPrimaryKeys),
+      this.referralService.getReferralsForDepositsAndUserAddress(depositPrimaryKeys, userAddress),
+    ]);
+    return {
+      "op-rebates": opRebateRewards,
+      referrals: referralRewards,
+    };
+  }
+
+  public enrichDepositsWithRewards(
+    deposits: Deposit[],
+    rewards: {
+      "op-rebates": Reward[];
+      referrals: Referral[];
+    },
+  ) {
+    return deposits.map((deposit) => {
+      const opRebate = rewards["op-rebates"].find((reward) => reward.depositPrimaryKey === deposit.id);
+      const referral = rewards["referrals"].find((reward) => reward.id === deposit.id);
+
+      return {
+        deposit,
+        rewards: opRebate ? this.formatOpRebate(opRebate) : referral ? this.formatReferral(referral) : undefined,
+      };
+    });
+  }
+
+  public formatOpRebate(reward: Reward) {
+    return {
+      type: "op-rebates",
+      rate: reward.metadata.rate,
+      amount: reward.amount,
+      usd: reward.amountUsd,
+    };
+  }
+
+  public formatReferral(referral: Referral) {
+    return {
+      type: "referrals",
+      tier: this.referralService.getTierLevelByRate(referral.referralRate),
+      rate: referral.appliedRate,
+      referralRate: referral.referralRate,
+      multiplier: referral.multiplier,
+      amount: referral.acxRewards,
+      usd: new BigNumber(referral.acxUsdPrice)
+        .multipliedBy(ethers.utils.formatUnits(referral.acxRewards, 18))
+        .toFixed(),
+    };
+  }
+}

--- a/src/modules/scraper/module.ts
+++ b/src/modules/scraper/module.ts
@@ -93,7 +93,7 @@ export class ScraperModule {
         DepositModule.forRoot(moduleOptions),
         AirdropModule.forRoot(moduleOptions),
         ReferralModule.forRoot(moduleOptions),
-        RewardModule,
+        RewardModule.forRoot(moduleOptions),
         BullModule.registerQueue({
           name: ScraperQueue.BlockNumber,
         }),

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -403,7 +403,7 @@ describe("GET /v2/deposits", () => {
   });
 });
 
-describe("GET /deposits/tx-page", () => {
+describe.only("GET /deposits/tx-page", () => {
   beforeAll(async () => {
     depositFixture = app.get(DepositFixture);
     rewardFixture = app.get(RewardFixture);
@@ -481,7 +481,7 @@ describe("GET /deposits/tx-page", () => {
     expect(response.body.deposits).toHaveLength(4);
   });
 
-  it("200 with populated rewards for 'depositorOrRecipientAddress' query param", async () => {
+  it("200 for 'depositorOrRecipientAddress' query param", async () => {
     await rewardFixture.insertReward({
       depositPrimaryKey: 3,
       recipient: depositorAddr,

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -403,7 +403,7 @@ describe("GET /v2/deposits", () => {
   });
 });
 
-describe.only("GET /deposits/tx-page", () => {
+describe("GET /deposits/tx-page", () => {
   beforeAll(async () => {
     depositFixture = app.get(DepositFixture);
     rewardFixture = app.get(RewardFixture);

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -481,6 +481,28 @@ describe("GET /deposits/tx-page", () => {
     expect(response.body.deposits).toHaveLength(4);
   });
 
+  it("200 with populated rewards for 'depositorOrRecipientAddress' query param", async () => {
+    await rewardFixture.insertReward({
+      depositPrimaryKey: 3,
+      recipient: depositorAddr,
+      type: "op-rebates",
+      metadata: { type: "op-rebates", rate: 0.95 },
+      amount: "1000000000000000000",
+      amountUsd: "1",
+      rewardTokenId: token.id,
+    });
+    await referralService.cumputeReferralStats();
+    await referralService.refreshMaterializedView();
+
+    const response = await request(app.getHttpServer()).get("/deposits/tx-page").query({
+      depositorOrRecipientAddress: depositorAddr,
+    });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(2);
+    expect(response.body.deposits[0].rewards.type).toBe("referrals");
+    expect(response.body.deposits[1].rewards.type).toBe("op-rebates");
+  });
+
   it("200 for 'status' query params", async () => {
     const response = await request(app.getHttpServer()).get("/deposits/tx-page").query({ status: "filled" });
     expect(response.status).toBe(200);
@@ -513,28 +535,6 @@ describe("GET /deposits/tx-page", () => {
     expect(response.body.deposits).toHaveLength(4);
     expect(response.body.deposits[0].depositId).toBe(2);
     expect(response.body.deposits[2].depositId).toBe(4);
-  });
-
-  it("200 for 'include[]=rewards' query param", async () => {
-    await rewardFixture.insertReward({
-      depositPrimaryKey: 3,
-      recipient: depositorAddr,
-      type: "op-rebates",
-      metadata: { type: "op-rebates", rate: 0.95 },
-      amount: "1000000000000000000",
-      amountUsd: "1",
-      rewardTokenId: token.id,
-    });
-    await referralService.cumputeReferralStats();
-    await referralService.refreshMaterializedView();
-
-    const response = await request(app.getHttpServer()).get("/deposits/tx-page").query("include[]=rewards").query({
-      depositorOrRecipientAddress: depositorAddr,
-    });
-    expect(response.status).toBe(200);
-    expect(response.body.deposits).toHaveLength(2);
-    expect(response.body.deposits[0].rewards.type).toBe("referrals");
-    expect(response.body.deposits[1].rewards.type).toBe("op-rebates");
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Closes ACX-1714

This adds a new `RewardService` in `src/modules/rewards/services/reward-service.ts` which serves as an umbrella service for all reward-related functionality. This service is used by the deposits module to include related rewards for a deposit.

Requires #286 