### PR TITLE
feat: add `include` query params to deposits v2 query

### DIFF
--- a/src/modules/deposit/entry-point/http/dto.ts
+++ b/src/modules/deposit/entry-point/http/dto.ts
@@ -1,6 +1,18 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsDateString, IsEnum, IsInt, IsOptional, IsString, Max, Min, IsPositive, IsBoolean } from "class-validator";
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  IsPositive,
+  IsBoolean,
+  IsArray,
+  ArrayMaxSize,
+} from "class-validator";
 
 export class GetDepositsQuery {
   @IsOptional()
@@ -98,6 +110,18 @@ export class GetDepositsV2Query {
   )
   @ApiProperty({ example: "filled", required: false })
   status: "filled" | "pending";
+
+  @IsOptional()
+  @IsArray()
+  @IsEnum(
+    {
+      TOKEN: "token",
+    },
+    { each: true, message: "Must be one of: 'token'" },
+  )
+  @ArrayMaxSize(1)
+  @ApiProperty({ example: ["token"], required: false })
+  include: Array<"token">;
 
   @IsOptional()
   @IsInt()

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -347,6 +347,7 @@ export function formatDeposit(deposit: Deposit) {
     destinationChainId: deposit.destinationChainId,
     assetAddr: deposit.tokenAddr,
     assetSymbol: deposit.token?.symbol,
+    assetDecimals: deposit.token?.decimals,
     depositorAddr: deposit.depositorAddr,
     recipientAddr: deposit.recipientAddr,
     message: deposit.message,

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -310,6 +310,7 @@ describe("GET /v2/deposits", () => {
         status: "filled",
         sourceChainId: 137,
         destinationChainId: 42161,
+        tokenAddr: usdc.address,
         depositDate: new Date("2023-02-01"),
         tokenId: token.id,
       },
@@ -339,7 +340,7 @@ describe("GET /v2/deposits", () => {
   it("200 for 'tokenAddress' query params", async () => {
     const response = await request(app.getHttpServer()).get("/v2/deposits").query({ tokenAddress: usdc.address });
     expect(response.status).toBe(200);
-    expect(response.body.deposits).toHaveLength(1);
+    expect(response.body.deposits).toHaveLength(2);
   });
 
   it("200 for 'depositorOrRecipientAddress', 'depositorAddress' and 'recipientAddress' query params", async () => {
@@ -374,6 +375,20 @@ describe("GET /v2/deposits", () => {
     ]);
     expect(response1.status).toBe(400);
     expect(response2.status).toBe(400);
+  });
+
+  it("200 for 'include[]=token' query param", async () => {
+    const response = await request(app.getHttpServer())
+      .get("/v2/deposits")
+      .query("include[]=token")
+      .query({ tokenAddress: token.address });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(2);
+    expect(response.body.deposits[0].token).toMatchObject({
+      address: token.address,
+      symbol: token.symbol,
+      decimals: token.decimals,
+    });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Based on https://github.com/across-protocol/scraper-api/pull/296#pullrequestreview-1746039964 but opening a new PR because branch name changed.