### PR TITLE
fix: fee breakdown zero values

### DIFF
--- a/src/modules/scraper/adapter/messaging/FeeBreakdownConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/FeeBreakdownConsumer.ts
@@ -63,7 +63,7 @@ export class FeeBreakdownConsumer {
     decimals: number,
     destinationChainId: number,
   ) {
-    const calcPctValues = makePctValuesCalculator(fillTx.fillAmount, priceUsd, decimals);
+    const calcPctValues = makePctValuesCalculator(fillTx.totalFilledAmount, priceUsd, decimals);
     const { feeUsd } = await this.gasFeesService.getFillTxNetworkFee(destinationChainId, fillTx.hash);
 
     const lpFeePctValues = calcPctValues(fillTx.realizedLpFeePct);

--- a/src/modules/scraper/adapter/messaging/FeeBreakdownConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/FeeBreakdownConsumer.ts
@@ -73,7 +73,7 @@ export class FeeBreakdownConsumer {
     const relayFeePctValues = calcPctValues(fillRelayerFeePct);
     const bridgeFeePctValues = calcPctValues(new BigNumber(fillTx.realizedLpFeePct).plus(fillRelayerFeePct).toString());
 
-    const { gasFeePct, capitalFeePct, capitalFeeUsd } = deriveRelayerFeeComponents(
+    const { gasFeeUsd, gasFeePct, capitalFeePct, capitalFeeUsd } = deriveRelayerFeeComponents(
       feeUsd,
       relayFeePctValues.pctAmountUsd,
       relayFeePctValues.pct,
@@ -86,7 +86,7 @@ export class FeeBreakdownConsumer {
       relayCapitalFeeUsd: capitalFeeUsd,
       relayCapitalFeePct: toWeiPct(capitalFeePct),
       relayCapitalFeeAmount: new BigNumber(fillTx.fillAmount).multipliedBy(capitalFeePct).toFixed(0),
-      relayGasFeeUsd: feeUsd,
+      relayGasFeeUsd: gasFeeUsd,
       relayGasFeePct: toWeiPct(gasFeePct),
       relayGasFeeAmount: new BigNumber(fillTx.fillAmount).multipliedBy(gasFeePct).toFixed(0),
       totalBridgeFeeUsd: bridgeFeePctValues.pctAmountUsd,

--- a/src/modules/scraper/utils/fees.spec.ts
+++ b/src/modules/scraper/utils/fees.spec.ts
@@ -20,6 +20,26 @@ describe("calcPctValues", () => {
     expect(formattedPctAmount).toEqual("0.5");
     expect(pctAmountUsd).toEqual("1000");
   });
+
+  it("should handle 0 values correctly", () => {
+    const weiPct = "0";
+    const totalAmount = "1000000000000000000"; // 1
+    const usdPrice = "2000";
+    const tokenDecimals = 18;
+
+    const { pct, formattedPct, pctAmount, formattedPctAmount, pctAmountUsd } = calcPctValues(
+      weiPct,
+      totalAmount,
+      usdPrice,
+      tokenDecimals,
+    );
+
+    expect(pct).toEqual("0");
+    expect(formattedPct).toEqual("0");
+    expect(pctAmount).toEqual("0");
+    expect(formattedPctAmount).toEqual("0.0");
+    expect(pctAmountUsd).toEqual("0");
+  });
 });
 
 describe("deriveRelayerFeeComponents", () => {
@@ -37,5 +57,21 @@ describe("deriveRelayerFeeComponents", () => {
     expect(gasFeePct).toEqual("0.25");
     expect(capitalFeeUsd).toEqual("1");
     expect(capitalFeePct).toEqual("0.25");
+  });
+
+  it("should handle 0 values correctly", () => {
+    const gasFeeUsd = "1";
+    const relayerFeeUsd = "0";
+    const relayerFeePct = "0";
+
+    const { gasFeePct, capitalFeeUsd, capitalFeePct } = deriveRelayerFeeComponents(
+      gasFeeUsd,
+      relayerFeeUsd,
+      relayerFeePct,
+    );
+
+    expect(gasFeePct).toEqual("0");
+    expect(capitalFeeUsd).toEqual("0");
+    expect(capitalFeePct).toEqual("0");
   });
 });

--- a/src/modules/scraper/utils/fees.ts
+++ b/src/modules/scraper/utils/fees.ts
@@ -47,9 +47,12 @@ export function deriveRelayerFeeComponents(
   relayerFeeUsd: string,
   relayerFeePct: BigNumber | number | string,
 ) {
-  const gasFeePct = new BigNumber(gasFeeUsd).dividedBy(relayerFeeUsd).multipliedBy(relayerFeePct);
-  const capitalFeeUsd = new BigNumber(relayerFeeUsd).minus(gasFeeUsd);
-  const capitalFeePct = new BigNumber(relayerFeePct).minus(gasFeePct);
+  const isRelayerFeeZero = new BigNumber(relayerFeeUsd).isZero();
+  const gasFeePct = isRelayerFeeZero
+    ? 0
+    : new BigNumber(gasFeeUsd).dividedBy(relayerFeeUsd).multipliedBy(relayerFeePct);
+  const capitalFeeUsd = isRelayerFeeZero ? 0 : new BigNumber(relayerFeeUsd).minus(gasFeeUsd);
+  const capitalFeePct = isRelayerFeeZero ? 0 : new BigNumber(relayerFeePct).minus(gasFeePct);
   return {
     gasFeeUsd,
     gasFeePct: gasFeePct.toFixed(),

--- a/src/modules/scraper/utils/fees.ts
+++ b/src/modules/scraper/utils/fees.ts
@@ -54,7 +54,7 @@ export function deriveRelayerFeeComponents(
   const capitalFeeUsd = isRelayerFeeZero ? 0 : new BigNumber(relayerFeeUsd).minus(gasFeeUsd);
   const capitalFeePct = isRelayerFeeZero ? 0 : new BigNumber(relayerFeePct).minus(gasFeePct);
   return {
-    gasFeeUsd,
+    gasFeeUsd: isRelayerFeeZero ? "0" : gasFeeUsd,
     gasFeePct: gasFeePct.toFixed(),
     capitalFeeUsd: capitalFeeUsd.toFixed(),
     capitalFeePct: capitalFeePct.toFixed(),

--- a/src/modules/web3/model/tx-receipt.entity.ts
+++ b/src/modules/web3/model/tx-receipt.entity.ts
@@ -12,10 +12,10 @@ export class TransactionReceipt {
   @Column()
   from: string;
 
-  @Column()
+  @Column({ nullable: true })
   to: string;
 
-  @Column()
+  @Column({ nullable: true })
   contractAddress: string;
 
   @Column()

--- a/src/modules/web3/model/tx-receipt.entity.ts
+++ b/src/modules/web3/model/tx-receipt.entity.ts
@@ -13,7 +13,7 @@ export class TransactionReceipt {
   from: string;
 
   @Column({ nullable: true })
-  to: string;
+  to?: string;
 
   @Column({ nullable: true })
   contractAddress: string;

--- a/src/modules/web3/model/tx-receipt.entity.ts
+++ b/src/modules/web3/model/tx-receipt.entity.ts
@@ -16,7 +16,7 @@ export class TransactionReceipt {
   to?: string;
 
   @Column({ nullable: true })
-  contractAddress: string;
+  contractAddress?: string;
 
   @Column()
   transactionIndex: number;


### PR DESCRIPTION
The `FeeBreakdownConsumer` didn't correctly handle `0` values. If a slow fill, for example, occurs then the `relayerFeePct` is `0`. 