### PR TITLE
fix: use correct deposit primary key

### DIFF
--- a/src/modules/referral/services/service.ts
+++ b/src/modules/referral/services/service.ts
@@ -193,7 +193,7 @@ export class ReferralService {
       this.depositRepository.query(getReferralsTotalQuery(), [address]),
     ]);
 
-    const depositPrimaryKeys = referrals.map((referral) => referral.depositId);
+    const depositPrimaryKeys = referrals.map((referral) => referral.id);
     const deposits = await this.depositRepository.find({
       where: { id: In(depositPrimaryKeys) },
     });


### PR DESCRIPTION
`GET /rewards/referrals` was crashing due usage of wrong id