### PR TITLE
fix: op rebate rewards for empty deposit pks

### DIFF
--- a/src/modules/rewards/services/op-rebate-service.ts
+++ b/src/modules/rewards/services/op-rebate-service.ts
@@ -103,6 +103,9 @@ export class OpRebateService {
   }
 
   public async getOpRebateRewardsForDepositPrimaryKeys(depositPrimaryKeys: number[]) {
+    if (!depositPrimaryKeys.length) {
+      return [];
+    }
     const rewardsQuery = this.rewardRepository
       .createQueryBuilder("r")
       .where("r.type = :type", { type: "op-rebates" })

--- a/src/modules/rewards/services/op-rebate-service.ts
+++ b/src/modules/rewards/services/op-rebate-service.ts
@@ -103,7 +103,7 @@ export class OpRebateService {
   }
 
   public async getOpRebateRewardsForDepositPrimaryKeys(depositPrimaryKeys: number[]) {
-    if (!depositPrimaryKeys.length) {
+    if (depositPrimaryKeys.length === 0) {
       return [];
     }
     const rewardsQuery = this.rewardRepository

--- a/test/deposit.e2e-spec.ts
+++ b/test/deposit.e2e-spec.ts
@@ -503,6 +503,16 @@ describe("GET /deposits/tx-page", () => {
     expect(response.body.deposits[1].rewards.type).toBe("op-rebates");
   });
 
+  it("200 for 'depositorOrRecipientAddress' query param and no deposits", async () => {
+    await Promise.all([rewardFixture.deleteAllRewards(), depositFixture.deleteAllDeposits()]);
+
+    const response = await request(app.getHttpServer()).get("/deposits/tx-page").query({
+      depositorOrRecipientAddress: depositorAddr,
+    });
+    expect(response.status).toBe(200);
+    expect(response.body.deposits).toHaveLength(0);
+  });
+
   it("200 for 'status' query params", async () => {
     const response = await request(app.getHttpServer()).get("/deposits/tx-page").query({ status: "filled" });
     expect(response.status).toBe(200);


### PR DESCRIPTION
For some reason TypeORM errors with
```
QueryFailedError: syntax error at or near ")"

at .PostgresQueryRunner.query ( /usr/src/app/src/driver/postgres/PostgresQueryRunner.ts:299 )
at .runMicrotasks
at .processTicksAndRejections ( node:internal/process/task_queues:96 )
at .SelectQueryBuilder.loadRawResults ( /usr/src/app/src/query-builder/SelectQueryBuilder.ts:3555 )
at .SelectQueryBuilder.executeEntitiesAndRawResults ( /usr/src/app/src/query-builder/SelectQueryBuilder.ts:3320 )
at .SelectQueryBuilder.getRawAndEntities ( /usr/src/app/src/query-builder/SelectQueryBuilder.ts:1597 )
at .SelectQueryBuilder.getMany ( /usr/src/app/src/query-builder/SelectQueryBuilder.ts:1687 )
at .OpRebateService.getOpRebateRewardsForDepositPrimaryKeys ( /usr/src/app/src/modules/rewards/services/op-rebate-service.ts:111 )
```
if you pass in an empty array into the query builder with the `IN` statement