### PR TITLE
fix: publish track fill event job in filled date consumer

### DIFF
--- a/src/modules/scraper/adapter/messaging/FillEventsConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/FillEventsConsumer.ts
@@ -19,7 +19,7 @@ export class FillEventsConsumer {
 
   @Process()
   private async process(job: Job<FillEventsQueueMessage>) {
-    const { depositId, originChainId, destinationToken, transactionHash } = job.data;
+    const { depositId, originChainId } = job.data;
     const deposit = await this.depositRepository.findOne({ where: { sourceChainId: originChainId, depositId } });
 
     if (!deposit) {
@@ -35,11 +35,6 @@ export class FillEventsConsumer {
 
     this.scraperQueuesService.publishMessage<DepositFilledDateQueueMessage>(ScraperQueue.DepositFilledDate, {
       depositId: deposit.id,
-    });
-    this.scraperQueuesService.publishMessage<TrackFillEventQueueMessage>(ScraperQueue.TrackFillEvent, {
-      depositId: deposit.id,
-      destinationToken,
-      fillTxHash: transactionHash,
     });
   }
 

--- a/src/modules/scraper/adapter/messaging/FillEventsConsumer2.ts
+++ b/src/modules/scraper/adapter/messaging/FillEventsConsumer2.ts
@@ -25,7 +25,7 @@ export class FillEventsConsumer2 {
 
   @Process()
   private async process(job: Job<FillEventsQueueMessage2>) {
-    const { depositId, originChainId, destinationToken, transactionHash } = job.data;
+    const { depositId, originChainId } = job.data;
     const deposit = await this.depositRepository.findOne({ where: { sourceChainId: originChainId, depositId } });
 
     if (!deposit) {
@@ -41,11 +41,6 @@ export class FillEventsConsumer2 {
 
     this.scraperQueuesService.publishMessage<DepositFilledDateQueueMessage>(ScraperQueue.DepositFilledDate, {
       depositId: deposit.id,
-    });
-    this.scraperQueuesService.publishMessage<TrackFillEventQueueMessage>(ScraperQueue.TrackFillEvent, {
-      depositId: deposit.id,
-      destinationToken,
-      fillTxHash: transactionHash,
     });
     this.scraperQueuesService.publishMessage<FeeBreakdownQueueMessage>(ScraperQueue.FeeBreakdown, {
       depositId: deposit.id,


### PR DESCRIPTION
I noticed a lot of errors in the logs
```
Dec 13 16:01:22 api-scraper-across-prod docker[4194253]: [Nest] 87  - 12/13/2023, 4:01:22 PM   ERROR [TrackFillEventConsumer] TrackFillEvent {"depositId":3424031,"destinationToken":"0x5AEa5775959fBC2557Cc8789bC1bf90A239D9a91","fillTxHash":"0x7b762c4555aaab29cc3d0551c488b8d2f9f2551c536d8ad06e9284861503c8c7"} failed: Error: Fill tx does not have a date
```

This PR aims to decrease the logs by publishing the track fill message in the `DepositFilledDateConsumer` to make sure that the filled date is populated