### PR TITLE
feat: add endpoint for backfilling filledDate

### DIFF
--- a/src/modules/scraper/entry-point/http/controller.ts
+++ b/src/modules/scraper/entry-point/http/controller.ts
@@ -33,6 +33,7 @@ import {
   SubmitFeeBreakdownBody,
   OpRebateRewardBody,
   BackfillFeeBreakdownBody,
+  BackfillFilledDateBody,
 } from "./dto";
 
 @Controller()
@@ -237,5 +238,14 @@ export class ScraperController {
   @ApiBearerAuth()
   async backfillFeeBreakdown(@Body() body: BackfillFeeBreakdownBody) {
     await this.scraperService.backfillFeeBreakdown(body);
+  }
+
+  @Post("scraper/deposit-filled-date/backfill")
+  @ApiTags("scraper")
+  @Roles(Role.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  async backfillFilledDate(@Body() body: BackfillFilledDateBody) {
+    await this.scraperService.backfillFilledDate(body);
   }
 }

--- a/src/modules/scraper/entry-point/http/dto.ts
+++ b/src/modules/scraper/entry-point/http/dto.ts
@@ -131,3 +131,10 @@ export class BackfillFeeBreakdownBody {
   @ApiProperty({ example: 0 })
   count?: number;
 }
+
+export class BackfillFilledDateBody {
+  @IsOptional()
+  @IsInt()
+  @ApiProperty({ example: 0 })
+  count?: number;
+}

--- a/src/modules/scraper/service.ts
+++ b/src/modules/scraper/service.ts
@@ -296,7 +296,6 @@ export class ScraperService {
     this.logger.debug(`[backfillFilledDate] found ${deposits.length} deposits`);
 
     for (const deposit of deposits) {
-      this.logger.debug(`[backfillFilledDate] get filled date for ${deposit.id}`);
       await this.scraperQueuesService.publishMessage<DepositFilledDateQueueMessage>(ScraperQueue.DepositFilledDate, {
         depositId: deposit.id,
       });


### PR DESCRIPTION
Admin endpoint for setting `filledDate`.

There are quite a lot of deposits where filled date is null even though they are filled. This is also causing a lot of errors in `TrackFillEventsConsumer`