### PR TITLE
fix: improve capped bridge fee pct

### DIFF
--- a/src/modules/scraper/adapter/messaging/CappedBridgeFeeConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/CappedBridgeFeeConsumer.ts
@@ -7,7 +7,7 @@ import BigNumber from "bignumber.js";
 
 import { CappedBridgeFeeQueueMessage, ScraperQueue } from ".";
 import { Deposit } from "../../../deposit/model/deposit.entity";
-import { AcrossContractsVersion } from "src/modules/web3/model/across-version";
+import { AcrossContractsVersion } from "../../../web3/model/across-version";
 
 /**
  * This consumer computes the the capped bridge fee percentage used for computing referral rewards

--- a/src/modules/scraper/adapter/messaging/CappedBridgeFeeConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/CappedBridgeFeeConsumer.ts
@@ -10,7 +10,7 @@ import { Deposit } from "../../../deposit/model/deposit.entity";
 import { AcrossContractsVersion } from "../../../web3/model/across-version";
 
 /**
- * This consumer computes the the capped bridge fee percentage used for computing referral rewards
+ * This consumer computes the capped bridge fee percentage used for computing referral rewards
  */
 @Processor(ScraperQueue.CappedBridgeFee)
 export class CappedBridgeFeeConsumer {

--- a/src/modules/scraper/adapter/messaging/CappedBridgeFeeUsdConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/CappedBridgeFeeUsdConsumer.ts
@@ -1,0 +1,93 @@
+import { OnQueueFailed, Process, Processor } from "@nestjs/bull";
+import { Logger } from "@nestjs/common";
+import { Job } from "bull";
+import { Repository } from "typeorm";
+import { InjectRepository } from "@nestjs/typeorm";
+import BigNumber from "bignumber.js";
+
+import { CappedBridgeFeeQueueMessage, ScraperQueue } from ".";
+import { Deposit } from "../../../deposit/model/deposit.entity";
+import { AcrossContractsVersion } from "src/modules/web3/model/across-version";
+
+/**
+ * This consumer computes the the capped bridge fee percentage used for computing referral rewards
+ */
+@Processor(ScraperQueue.CappedBridgeFee)
+export class CappedBridgeFeeConsumer {
+  private logger = new Logger(CappedBridgeFeeConsumer.name);
+
+  constructor(@InjectRepository(Deposit) private depositRepository: Repository<Deposit>) {}
+
+  @Process()
+  async process(job: Job<CappedBridgeFeeQueueMessage>) {
+    const { depositId } = job.data;
+    const deposit = await this.depositRepository.findOne({
+      where: { id: depositId },
+      relations: ["token", "outputToken", "price", "outputTokenPrice"],
+    });
+    if (!deposit) return;
+    const version: AcrossContractsVersion = deposit.outputTokenAddress
+      ? AcrossContractsVersion.V3
+      : AcrossContractsVersion.V2_5;
+
+    if (version === AcrossContractsVersion.V2_5) {
+      return;
+    }
+
+    this.retryIfNeeded(deposit);
+    await this.computeCappedBridgeFeePct(deposit);
+  }
+
+  private async computeCappedBridgeFeePct(deposit: Deposit) {
+    const wei = new BigNumber(10).pow(18);
+    const inputAmountUsd = new BigNumber(deposit.amount)
+      .multipliedBy(deposit.price.usd)
+      .dividedBy(new BigNumber(10).pow(deposit.token.decimals));
+    const outputAmountUsd = new BigNumber(deposit.outputAmount)
+      .multipliedBy(deposit.outputTokenPrice.usd)
+      .dividedBy(new BigNumber(10).pow(deposit.outputToken.decimals));
+    const bridgeFeePct = new BigNumber(1).minus(outputAmountUsd.dividedBy(inputAmountUsd));
+    const bridgeFeePctWei = bridgeFeePct.multipliedBy(wei);
+    const maxBridgeFeePct = wei.times(0.0012);
+    const bridgeFeePctCapped = BigNumber.min(bridgeFeePctWei, maxBridgeFeePct);
+
+    await this.depositRepository.update(
+      { id: deposit.id },
+      {
+        bridgeFeePct: bridgeFeePctCapped.toFixed(0),
+      },
+    );
+  }
+
+  private retryIfNeeded(deposit: Deposit) {
+    if (deposit.status !== "filled") throw new Error(`Deposit ${deposit.id} is not filled yet`);
+    // Check input token and input token price
+    if (!deposit.tokenId) throw new Error(`Deposit ${deposit.id} does not have a token yet`);
+    if (!deposit.priceId) throw new Error(`Deposit ${deposit.id} does not have a price yet`);
+    if (deposit.priceId && !deposit.price) {
+      throw new Error(`Deposit ${deposit.id} does not have a price relation`);
+    }
+    if (deposit.tokenId && !deposit.token) {
+      throw new Error(`Deposit ${deposit.id} does not have a token relation`);
+    }
+
+    // Check output token and output token price
+    if (!deposit.outputTokenId) {
+      throw new Error(`Deposit ${deposit.id} does not have an output token yet`);
+    }
+    if (!deposit.outputTokenPriceId) {
+      throw new Error(`Deposit ${deposit.id} does not have an output token price yet`);
+    }
+    if (deposit.outputTokenId && !deposit.outputToken) {
+      throw new Error(`Deposit ${deposit.id} does not have a token relation`);
+    }
+    if (deposit.outputTokenPriceId && !deposit.outputTokenPrice) {
+      throw new Error(`Deposit ${deposit.id} does not have a price relation`);
+    }
+  }
+
+  @OnQueueFailed()
+  private onQueueFailed(job: Job, error: Error) {
+    this.logger.error(`${ScraperQueue.CappedBridgeFee} ${JSON.stringify(job.data)} failed: ${error}`);
+  }
+}

--- a/src/modules/scraper/adapter/messaging/FillEventsV3Consumer.ts
+++ b/src/modules/scraper/adapter/messaging/FillEventsV3Consumer.ts
@@ -1,11 +1,16 @@
 import { OnQueueFailed, Process, Processor } from "@nestjs/bull";
 import { Logger } from "@nestjs/common";
 import { Job } from "bull";
-import { CappedBridgeFeeQueueMessage, DepositFilledDateQueueMessage, FeeBreakdownQueueMessage, FillEventsV3QueueMessage, ScraperQueue } from ".";
+import {
+  CappedBridgeFeeQueueMessage,
+  DepositFilledDateQueueMessage,
+  FeeBreakdownQueueMessage,
+  FillEventsV3QueueMessage,
+  ScraperQueue,
+} from ".";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Deposit, DepositFillTxV3 } from "../../../deposit/model/deposit.entity";
 import { Repository } from "typeorm";
-import { BigNumber } from "bignumber.js";
 import { ScraperQueuesService } from "../../service/ScraperQueuesService";
 
 @Processor(ScraperQueue.FillEventsV3)

--- a/src/modules/scraper/adapter/messaging/index.ts
+++ b/src/modules/scraper/adapter/messaging/index.ts
@@ -19,6 +19,7 @@ export enum ScraperQueue {
   FeeBreakdown = "FeeBreakdown",
   OpRebateReward = "OpRebateReward",
   MerkleDistributorClaim = "MerkleDistributorClaim",
+  CappedBridgeFee = "CappedBridgeFee",
 }
 
 export type BlocksEventsQueueMessage = {
@@ -138,4 +139,8 @@ export type OpRebateRewardMessage = {
 
 export type MerkleDistributorClaimQueueMessage = {
   claimId: number;
+};
+
+export type CappedBridgeFeeQueueMessage = {
+  depositId: number;
 };

--- a/src/modules/scraper/module.ts
+++ b/src/modules/scraper/module.ts
@@ -50,7 +50,7 @@ import { MerkleDistributorClaim } from "../airdrop/model/merkle-distributor-clai
 import { MerkleDistributorWindow } from "../airdrop/model/merkle-distributor-window.entity";
 import { SpeedUpEventsV3Consumer } from "./adapter/messaging/SpeedUpEventsV3Consumer";
 import { Token } from "../web3/model/token.entity";
-import { CappedBridgeFeeConsumer } from "./adapter/messaging/CappedBridgeFeeUsdConsumer";
+import { CappedBridgeFeeConsumer } from "./adapter/messaging/CappedBridgeFeeConsumer";
 
 @Module({})
 export class ScraperModule {

--- a/src/modules/scraper/module.ts
+++ b/src/modules/scraper/module.ts
@@ -50,6 +50,7 @@ import { MerkleDistributorClaim } from "../airdrop/model/merkle-distributor-clai
 import { MerkleDistributorWindow } from "../airdrop/model/merkle-distributor-window.entity";
 import { SpeedUpEventsV3Consumer } from "./adapter/messaging/SpeedUpEventsV3Consumer";
 import { Token } from "../web3/model/token.entity";
+import { CappedBridgeFeeConsumer } from "./adapter/messaging/CappedBridgeFeeUsdConsumer";
 
 @Module({})
 export class ScraperModule {
@@ -82,6 +83,7 @@ export class ScraperModule {
       FeeBreakdownConsumer,
       OpRebateRewardConsumer,
       MerkleDistributorClaimConsumer,
+      CappedBridgeFeeConsumer,
     ];
 
     return {
@@ -199,6 +201,9 @@ export class ScraperModule {
         }),
         BullModule.registerQueue({
           name: ScraperQueue.MerkleDistributorClaim,
+        }),
+        BullModule.registerQueue({
+          name: ScraperQueue.CappedBridgeFee,
         }),
       ],
       exports: [ScraperQueuesService],

--- a/src/modules/scraper/service/ScraperQueuesService.ts
+++ b/src/modules/scraper/service/ScraperQueuesService.ts
@@ -30,6 +30,7 @@ export class ScraperQueuesService {
     @InjectQueue(ScraperQueue.FeeBreakdown) private feeBreakdownsQueue: Queue,
     @InjectQueue(ScraperQueue.OpRebateReward) private opRebateRewardsQueue: Queue,
     @InjectQueue(ScraperQueue.MerkleDistributorClaim) private merkleDistributorClaimQueue: Queue,
+    @InjectQueue(ScraperQueue.CappedBridgeFee) private cappedBridgeFeeQueue: Queue,
   ) {
     this.queuesMap = {
       [ScraperQueue.BlocksEvents]: this.blocksEventsQueue,
@@ -52,6 +53,7 @@ export class ScraperQueuesService {
       [ScraperQueue.FeeBreakdown]: this.feeBreakdownsQueue,
       [ScraperQueue.OpRebateReward]: this.opRebateRewardsQueue,
       [ScraperQueue.MerkleDistributorClaim]: this.merkleDistributorClaimQueue,
+      [ScraperQueue.CappedBridgeFee]: this.cappedBridgeFeeQueue,
     };
   }
 


### PR DESCRIPTION
This PRs [removes the computation of the capped bridge fee pct](https://github.com/across-protocol/scraper-api/pull/353/files#diff-ecfac74c90bff76d0ddbb76c32110ca565d1b91dfebb79fce0ea9f9ad8a3d175L54) from the consumer that process V3 fill events and moves it to its own dedicated & retryable consumer: [CappedBridgeFeeConsumer](https://github.com/across-protocol/scraper-api/pull/353/files#diff-5f582b450e40be10f254993aa396a690607a8296a2f0a84b256bf968f2da7694). 
The reason is simple: for V3 deposits, the computation of the bridge fee percentage needs the prices of the input & output token. Fetching prices is done asynchronously, in a different consumer,  so there's no guarantee that they are available by the time the fills are processed for a particular deposit.

⚠️  Also, the bridge fee pct is computed based on the USD input and output amounts, to avoid issues when the output and input token have different decimals number 