### PR TITLE
fix: set correct initial message field for v3

### DIFF
--- a/src/modules/scraper/adapter/messaging/BlocksEventsConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/BlocksEventsConsumer.ts
@@ -376,6 +376,7 @@ export class BlocksEventsConsumer {
       fillDeadline,
       exclusivityDeadline,
       relayer,
+      message,
     } = event.args;
 
     const wei = BigNumber.from(10).pow(18);
@@ -411,6 +412,7 @@ export class BlocksEventsConsumer {
       fillDeadline: new Date(fillDeadline * 1000),
       exclusivityDeadline: exclusivityDeadlineDate,
       relayer,
+      message,
     });
   }
 


### PR DESCRIPTION
The initial message field was set incorrectly for v3 FundsDeposited events.