### PR TITLE
feat: add deposit gap check

### DIFF
--- a/migrations/1711039047259-DepositGapCheck.ts
+++ b/migrations/1711039047259-DepositGapCheck.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DepositGapCheck1711039047259 implements MigrationInterface {
+  name = "DepositGapCheck1711039047259";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "deposit_gap_check" (
+        "originChainId" integer NOT NULL, 
+        "depositId" integer NOT NULL, 
+        "passed" boolean NOT NULL, 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "PK_62655590811df1ec582a1f32f99" PRIMARY KEY ("originChainId", "depositId"))
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "deposit_gap_check"`);
+  }
+}

--- a/src/modules/configuration/index.ts
+++ b/src/modules/configuration/index.ts
@@ -75,18 +75,21 @@ export const configValues = () => ({
           startBlockNumber: 14819486,
           abi: JSON.stringify(EthereumSpokePool2Abi),
           acrossVersion: AcrossContractsVersion.V2,
+          firstDepositId: 0,
         },
         {
           address: "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5",
           startBlockNumber: 17125811,
           abi: JSON.stringify(EthereumSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
         {
           address: "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5",
           startBlockNumber: 17125812,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.optimism]: [
@@ -95,18 +98,21 @@ export const configValues = () => ({
           startBlockNumber: 8747136,
           abi: JSON.stringify(OptimismSpokePool2Abi),
           acrossVersion: AcrossContractsVersion.V2,
+          firstDepositId: 0,
         },
         {
           address: "0x6f26Bf09B1C792e3228e5467807a900A503c0281",
           startBlockNumber: 94233880,
           abi: JSON.stringify(OptimismSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
         {
           address: "0x6f26Bf09B1C792e3228e5467807a900A503c0281",
           startBlockNumber: 94233881,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.arbitrum]: [
@@ -115,18 +121,21 @@ export const configValues = () => ({
           startBlockNumber: 12741972,
           abi: JSON.stringify(ArbitrumSpokePool2Abi),
           acrossVersion: AcrossContractsVersion.V2,
+          firstDepositId: 0,
         },
         {
           address: "0xe35e9842fceaCA96570B734083f4a58e8F7C5f2A",
           startBlockNumber: 84268970,
           abi: JSON.stringify(ArbitrumSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
         {
           address: "0xe35e9842fceaCA96570B734083f4a58e8F7C5f2A",
           startBlockNumber: 84268971,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.boba]: [
@@ -135,6 +144,7 @@ export const configValues = () => ({
           startBlockNumber: 619993,
           abi: JSON.stringify(BobaSpokePool2Abi),
           acrossVersion: AcrossContractsVersion.V2,
+          firstDepositId: 0,
         },
       ],
       [ChainIds.polygon]: [
@@ -143,18 +153,21 @@ export const configValues = () => ({
           startBlockNumber: 28604263,
           abi: JSON.stringify(PolygonSpokePool2Abi),
           acrossVersion: AcrossContractsVersion.V2,
+          firstDepositId: 0,
         },
         {
           address: "0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096",
           startBlockNumber: 41954460,
           abi: JSON.stringify(PolygonSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
         {
           address: "0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096",
           startBlockNumber: 41954461,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.goerli]: [
@@ -163,6 +176,7 @@ export const configValues = () => ({
           startBlockNumber: 8824950,
           abi: JSON.stringify(GoerliSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.arbitrumGoerli]: [
@@ -171,6 +185,7 @@ export const configValues = () => ({
           startBlockNumber: 16711650,
           abi: JSON.stringify(GoerliSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.zkSyncTestnet]: [
@@ -179,6 +194,7 @@ export const configValues = () => ({
           startBlockNumber: 5000000,
           abi: JSON.stringify(GoerliSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.zkSyncMainnet]: [
@@ -187,12 +203,14 @@ export const configValues = () => ({
           startBlockNumber: 10352565,
           abi: JSON.stringify(EthereumSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
         {
           address: "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF",
           startBlockNumber: 10352566,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.base]: [
@@ -201,12 +219,14 @@ export const configValues = () => ({
           startBlockNumber: 2164878,
           abi: JSON.stringify(EthereumSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
         {
           address: "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
           startBlockNumber: 2164879,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.baseGoerli]: [
@@ -215,6 +235,7 @@ export const configValues = () => ({
           startBlockNumber: 7992905,
           abi: JSON.stringify(EthereumSpokePool2_5Abi),
           acrossVersion: AcrossContractsVersion.V2_5,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.baseSepolia]: [
@@ -223,6 +244,7 @@ export const configValues = () => ({
           startBlockNumber: 6082004,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.sepolia]: [
@@ -231,6 +253,7 @@ export const configValues = () => ({
           startBlockNumber: 5288470,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.linea]: [
@@ -239,6 +262,7 @@ export const configValues = () => ({
           startBlockNumber: 2721169,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
       [ChainIds.lineaGoerli]: [
@@ -247,6 +271,7 @@ export const configValues = () => ({
           startBlockNumber: 2782100,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
+          firstDepositId: 1000000,
         },
       ],
     },

--- a/src/modules/database/database.providers.ts
+++ b/src/modules/database/database.providers.ts
@@ -27,6 +27,7 @@ import { OpReward } from "../rewards/model/op-reward.entity";
 import { TransactionReceipt } from "../web3/model/tx-receipt.entity";
 import { QueueJobCount } from "../monitoring/model/QueueJobCount.entity";
 import { MerkleDistributorClaim } from "../airdrop/model/merkle-distributor-claim.entity";
+import { DepositGapCheck } from "../scraper/model/DepositGapCheck.entity";
 
 // TODO: Add db entities here
 const entities = [
@@ -56,6 +57,7 @@ const entities = [
   TransactionReceipt,
   QueueJobCount,
   MerkleDistributorClaim,
+  DepositGapCheck,
 ];
 
 @Injectable()

--- a/src/modules/deposit/service.ts
+++ b/src/modules/deposit/service.ts
@@ -309,6 +309,17 @@ export class DepositService {
     }
   }
 
+  public getFirstDepositIdFromSpokePoolConfig(chainId: number, throwIfNotFound = true) {
+    const contracts = this.appConfig.values.web3.spokePoolContracts[chainId];
+    if (!contracts && throwIfNotFound) {
+      throw new Error(`SpokePool contracts for chainId ${chainId} not found`);
+    }
+    if (!contracts) return undefined;
+
+    const firstDepositIds = contracts.map((contract) => contract.firstDepositId);
+    return Math.min(...firstDepositIds);
+  }
+
   private getFilteredDepositsQuery(
     queryBuilder: ReturnType<typeof this.depositRepository.createQueryBuilder>,
     filter: Partial<GetDepositsBaseQuery>,

--- a/src/modules/monitoring/module.ts
+++ b/src/modules/monitoring/module.ts
@@ -1,12 +1,12 @@
 import { Module, DynamicModule } from "@nestjs/common";
 import { HttpModule } from "@nestjs/axios";
+import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { ModuleOptions, RunMode } from "../../dynamic-module";
 import { AppConfigModule } from "../configuration/configuration.module";
 import { SlackService } from "./adapter/slack/service";
 import { MonitoringService } from "./service";
 import { SlackReportingCron } from "./service/slack-reporting-cron";
-import { TypeOrmModule } from "@nestjs/typeorm";
 import { QueueJobCount } from "./model/QueueJobCount.entity";
 
 @Module({})
@@ -32,7 +32,7 @@ export class MonitoringModule {
         ...module,
         providers: [...module.providers, SlackService, MonitoringService, SlackReportingCron],
         imports: [...module.imports, HttpModule, AppConfigModule, TypeOrmModule.forFeature([QueueJobCount])],
-        exports: [],
+        exports: [MonitoringService],
       };
     }
 

--- a/src/modules/scraper/adapter/db/DepositGapCheckFixture.ts
+++ b/src/modules/scraper/adapter/db/DepositGapCheckFixture.ts
@@ -1,0 +1,31 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { getRandomInt } from "../../../../utils";
+import { DepositGapCheck } from "../../model/DepositGapCheck.entity";
+
+@Injectable()
+export class DepositGapCheckFixture {
+  public constructor(
+    @InjectRepository(DepositGapCheck) private depositGapCheckRepository: Repository<DepositGapCheck>,
+  ) {}
+
+  public insertDepositGapCheck(depositGapCheckArgs: Partial<DepositGapCheck>) {
+    const check = this.depositGapCheckRepository.create(mockDepositGapCheckEntity(depositGapCheckArgs));
+    return this.depositGapCheckRepository.save(check);
+  }
+
+  public deleteAllDepositGapChecks() {
+    return this.depositGapCheckRepository.query(`truncate table "deposit_gap_check" restart identity cascade`);
+  }
+}
+
+export function mockDepositGapCheckEntity(overrides: Partial<DepositGapCheck>) {
+  return {
+    originChainId: getRandomInt(),
+    depositId: getRandomInt(),
+    passed: true,
+    ...overrides,
+  };
+}

--- a/src/modules/scraper/model/DepositGapCheck.entity.ts
+++ b/src/modules/scraper/model/DepositGapCheck.entity.ts
@@ -1,0 +1,19 @@
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from "typeorm";
+
+/**
+ * Table that stores the deposit ids for which the preceding deposits don't have gaps.
+ */
+@Entity()
+export class DepositGapCheck {
+  @PrimaryColumn()
+  originChainId: number;
+
+  @PrimaryColumn()
+  depositId: number;
+
+  @Column()
+  passed: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/modules/scraper/module.ts
+++ b/src/modules/scraper/module.ts
@@ -51,18 +51,27 @@ import { MerkleDistributorWindow } from "../airdrop/model/merkle-distributor-win
 import { SpeedUpEventsV3Consumer } from "./adapter/messaging/SpeedUpEventsV3Consumer";
 import { Token } from "../web3/model/token.entity";
 import { CappedBridgeFeeConsumer } from "./adapter/messaging/CappedBridgeFeeConsumer";
+import { DepositsGapDetectionCron } from "./service/DepositsGapDetectionCron";
+import { MonitoringModule } from "../monitoring/module";
+import { DepositGapCheck } from "./model/DepositGapCheck.entity";
+import { DepositGapCheckFixture } from "./adapter/db/DepositGapCheckFixture";
+import { DepositGapService } from "./service/DepositGapService";
 
 @Module({})
 export class ScraperModule {
   static forRoot(moduleOptions: ModuleOptions): DynamicModule {
+    const crons = [QueuesMonitoringCron, DepositsGapDetectionCron];
+    const fixtures = [DepositGapCheckFixture];
     const providers: Provider<any>[] = [
+      ...crons,
+      ...fixtures,
       ScraperService,
       ScraperQueuesService,
-      QueuesMonitoringCron,
       SuggestedFeesService,
       TrackService,
       GasFeesService,
       OpRebateService,
+      DepositGapService,
       BlocksEventsConsumer,
       MerkleDistributorBlocksEventsConsumer,
       MerkleDistributorBlocksEventsConsumerV2,
@@ -105,6 +114,7 @@ export class ScraperModule {
           MerkleDistributorClaim,
           MerkleDistributorWindow,
           Token,
+          DepositGapCheck,
         ]),
         MarketPriceModule.forRoot(moduleOptions),
         HttpModule,
@@ -112,6 +122,7 @@ export class ScraperModule {
         AirdropModule.forRoot(moduleOptions),
         ReferralModule.forRoot(moduleOptions),
         RewardModule.forRoot(moduleOptions),
+        MonitoringModule.forRoot(moduleOptions),
         BullModule.registerQueue({
           name: ScraperQueue.BlockNumber,
         }),

--- a/src/modules/scraper/service/DepositGapService.ts
+++ b/src/modules/scraper/service/DepositGapService.ts
@@ -1,0 +1,101 @@
+import { Injectable } from "@nestjs/common";
+import { DataSource, Repository } from "typeorm";
+import { DepositGapCheck } from "../model/DepositGapCheck.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { DepositService } from "../../deposit/service";
+import { Deposit } from "../../deposit/model/deposit.entity";
+
+export type DepositGapInterval = {
+  fromDepositId: number;
+  toDepositId: number;
+};
+
+type CheckDepositGapsResult = {
+  gapIntervals: DepositGapInterval[];
+  gapCheckPassDepositId?: number;
+  lastDepositId?: number;
+};
+
+const DEPOSITS_GAP_DETECTION_LIMIT = 50;
+
+@Injectable()
+export class DepositGapService {
+  constructor(
+    private dataSource: DataSource,
+    private depositService: DepositService,
+    @InjectRepository(DepositGapCheck) private depositGapCheckRepository: Repository<DepositGapCheck>,
+    @InjectRepository(Deposit) private depositRepository: Repository<Deposit>,
+  ) {}
+
+  async markDepositGapCheckAsPassed(depositId: number, originChainId: number) {
+    return this.dataSource
+      .createQueryBuilder()
+      .insert()
+      .into(DepositGapCheck)
+      .values({ depositId, originChainId, passed: true })
+      .orUpdate(["passed"], ["originChainId", "depositId"])
+      .execute();
+  }
+
+  async getLastDepositThatPassedGapCheck(originChainId: number) {
+    return this.depositGapCheckRepository.findOne({
+      where: { originChainId, passed: true },
+      order: { depositId: "DESC" },
+    });
+  }
+
+  async getDepositToStartGapCheck(chainId: number) {
+    const lastDepositGapCheck = await this.getLastDepositThatPassedGapCheck(chainId);
+    return lastDepositGapCheck
+      ? lastDepositGapCheck.depositId + 1
+      : this.depositService.getFirstDepositIdFromSpokePoolConfig(chainId);
+  }
+
+  async checkDepositGaps(chainId: number, gapsLimit = DEPOSITS_GAP_DETECTION_LIMIT): Promise<CheckDepositGapsResult> {
+    const gapIntervals: DepositGapInterval[] = [];
+    let gapCheckPassDepositId;
+    const lastDeposit = await this.depositRepository.findOne({
+      where: { sourceChainId: chainId },
+      order: { depositId: "DESC" },
+    });
+
+    if (!lastDeposit) return { gapIntervals, lastDepositId: lastDeposit?.depositId, gapCheckPassDepositId };
+
+    const firstDepositId = await this.getDepositToStartGapCheck(chainId);
+    let gapDetected = false;
+
+    for (let i = firstDepositId; i <= lastDeposit.depositId; i++) {
+      const deposit = await this.depositRepository.findOne({ where: { sourceChainId: chainId, depositId: i } });
+
+      if (deposit) {
+        if (!gapDetected) {
+          gapCheckPassDepositId = deposit.depositId;
+        }
+        if (gapIntervals.length === gapsLimit) {
+          break;
+        }
+      } else {
+        gapDetected = true;
+
+        if (gapIntervals.length === 0) {
+          gapIntervals.push({
+            fromDepositId: i,
+            toDepositId: i,
+          });
+        } else {
+          const lastInterval = gapIntervals[gapIntervals.length - 1];
+          if (lastInterval.toDepositId === i - 1) {
+            lastInterval.toDepositId = i;
+          } else {
+            gapIntervals.push({
+              fromDepositId: i,
+              toDepositId: i,
+            });
+          }
+        }
+      }
+    }
+
+    return { gapIntervals, lastDepositId: lastDeposit.depositId, gapCheckPassDepositId };
+  }
+}

--- a/src/modules/scraper/service/DepositsGapDetectionCron.ts
+++ b/src/modules/scraper/service/DepositsGapDetectionCron.ts
@@ -49,9 +49,9 @@ export class DepositsGapDetectionCron {
 
     for (const chainId of chainIds) {
       this.logger.log(`Detecting deposits gap for chainId: ${chainId}`);
-      const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await this.depositGapService.checkDepositGaps(
+      const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await this.depositGapService.checkDepositGaps({
         chainId,
-      );
+      });
       if (gapCheckPassDepositId) {
         await this.depositGapService.markDepositGapCheckAsPassed(gapCheckPassDepositId, chainId);
       }

--- a/src/modules/scraper/service/DepositsGapDetectionCron.ts
+++ b/src/modules/scraper/service/DepositsGapDetectionCron.ts
@@ -127,7 +127,7 @@ export class DepositsGapDetectionCron {
           elements: [
             {
               type: "text",
-              text: `deposits from ${gapInterval.fromDepositId} to ${gapInterval.toDepositId}\n(previous: ${gapInterval.previousKnownDeposit?.depositId} ${gapInterval.previousKnownDeposit?.blockNumber}, next: ${gapInterval.nextKnownDeposit?.depositId} ${gapInterval.nextKnownDeposit?.blockNumber}`,
+              text: `deposit id from ${gapInterval.fromDepositId} to ${gapInterval.toDepositId}\n(previous id: ${gapInterval.previousKnownDeposit?.depositId} block: ${gapInterval.previousKnownDeposit?.blockNumber}, next id:${gapInterval.nextKnownDeposit?.depositId} block:${gapInterval.nextKnownDeposit?.blockNumber}`,
             },
           ],
         });

--- a/src/modules/scraper/service/DepositsGapDetectionCron.ts
+++ b/src/modules/scraper/service/DepositsGapDetectionCron.ts
@@ -1,0 +1,173 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { LessThan, MoreThan, Repository } from "typeorm";
+
+import { EnhancedCron } from "../../../utils";
+import { AppConfig } from "../../configuration/configuration.service";
+import { Deposit } from "../../deposit/model/deposit.entity";
+import { MonitoringService } from "../../monitoring/service";
+import { DepositGapInterval, DepositGapService } from "./DepositGapService";
+
+export type DepositGapIntervalWithBlocks = DepositGapInterval & {
+  previousKnownDeposit?: { depositId: number; blockNumber: number };
+  nextKnownDeposit?: { depositId: number; blockNumber: number };
+};
+
+@Injectable()
+export class DepositsGapDetectionCron {
+  private logger = new Logger(DepositsGapDetectionCron.name);
+  private lock = false;
+
+  constructor(
+    private appConfig: AppConfig,
+    @InjectRepository(Deposit) private depositRepository: Repository<Deposit>,
+    private monitoringService: MonitoringService,
+    private depositGapService: DepositGapService,
+  ) {}
+
+  @EnhancedCron("0 5/10 * * * *")
+  async run() {
+    try {
+      if (this.lock) {
+        this.logger.warn("DepositsGapDetectionCron is locked");
+        return;
+      }
+      this.lock = true;
+
+      await this.detectDepositsGap();
+
+      this.lock = false;
+    } catch (error) {
+      this.logger.error(error);
+      this.lock = false;
+    }
+  }
+
+  private async detectDepositsGap() {
+    const chainIds = this.appConfig.values.spokePoolsEventsProcessingChainIds;
+    const chainGapIntervals: Record<number, DepositGapInterval[]> = {};
+
+    for (const chainId of chainIds) {
+      this.logger.log(`Detecting deposits gap for chainId: ${chainId}`);
+      const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await this.depositGapService.checkDepositGaps(
+        chainId,
+      );
+      if (gapCheckPassDepositId) {
+        await this.depositGapService.markDepositGapCheckAsPassed(gapCheckPassDepositId, chainId);
+      }
+      const gapIntervalsWithBlocks = await this.attachBlocksToDepositGaps(gapIntervals, chainId);
+      if (gapIntervalsWithBlocks.length > 0) {
+        this.logger.log(
+          `Detected deposits gap for chainId: ${chainId} (lastDepositId: ${lastDepositId}) ${JSON.stringify(
+            gapIntervalsWithBlocks,
+          )}`,
+        );
+        chainGapIntervals[chainId] = gapIntervalsWithBlocks;
+      }
+    }
+    await this.monitoringService.postSlackMessage(this.formatSlackPayload(chainGapIntervals));
+  }
+
+  private async attachBlocksToDepositGaps(gapIntervals: DepositGapInterval[], chainId: number) {
+    const gapIntervalsWithBlocks: DepositGapIntervalWithBlocks[] = [];
+
+    for (const interval of gapIntervals) {
+      const previousKnownDeposit = await this.depositRepository.findOne({
+        where: { sourceChainId: chainId, depositId: LessThan(interval.fromDepositId) },
+        order: { depositId: "DESC" },
+      });
+      const nextKnownDeposit = await this.depositRepository.findOne({
+        where: { sourceChainId: chainId, depositId: MoreThan(interval.toDepositId) },
+        order: { depositId: "ASC" },
+      });
+
+      gapIntervalsWithBlocks.push({
+        ...interval,
+        previousKnownDeposit: previousKnownDeposit
+          ? {
+              depositId: previousKnownDeposit.depositId,
+              blockNumber: previousKnownDeposit.blockNumber,
+            }
+          : // using null instead of undefined because JSON.stringify will remove undefined values
+            null,
+        nextKnownDeposit: nextKnownDeposit
+          ? {
+              depositId: nextKnownDeposit.depositId,
+              blockNumber: nextKnownDeposit.blockNumber,
+            }
+          : // using null instead of undefined because JSON.stringify will remove undefined values
+            null,
+      });
+    }
+
+    return gapIntervalsWithBlocks;
+  }
+
+  formatSlackPayload(chainGapIntervals: Record<number, DepositGapIntervalWithBlocks[]>) {
+    const text = [];
+
+    for (const chainId of Object.keys(chainGapIntervals)) {
+      const gapIntervals: DepositGapIntervalWithBlocks[] = chainGapIntervals[chainId];
+      text.push({
+        type: "rich_text_section",
+        elements: [
+          {
+            type: "text",
+            text: `\n\nChainId ${chainId}`,
+            style: {
+              bold: true,
+            },
+          },
+        ],
+      });
+      const bullets = [];
+      for (const gapInterval of gapIntervals) {
+        bullets.push({
+          type: "rich_text_section",
+          elements: [
+            {
+              type: "text",
+              text: `deposits from ${gapInterval.fromDepositId} to ${gapInterval.toDepositId}\n(previous: ${gapInterval.previousKnownDeposit?.depositId} ${gapInterval.previousKnownDeposit?.blockNumber}, next: ${gapInterval.nextKnownDeposit?.depositId} ${gapInterval.nextKnownDeposit?.blockNumber}`,
+            },
+          ],
+        });
+      }
+      text.push({
+        type: "rich_text_list",
+        style: "bullet",
+        elements: bullets,
+      });
+    }
+    const payload = {
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: "Deposit gaps detected :collision:",
+            emoji: true,
+          },
+        },
+        {
+          type: "rich_text",
+          elements: text,
+        },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "plain_text",
+              text: `:clock1: ${new Date()}`,
+              emoji: true,
+            },
+          ],
+        },
+        {
+          type: "divider",
+        },
+      ],
+    };
+
+    return payload;
+  }
+}

--- a/test/scraper/deposit-gap.e2e-spec.ts
+++ b/test/scraper/deposit-gap.e2e-spec.ts
@@ -1,0 +1,183 @@
+import { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+
+import { DepositGapCheckFixture } from "../../src/modules/scraper/adapter/db/DepositGapCheckFixture";
+import { DepositGapService } from "../../src/modules/scraper/service/DepositGapService";
+import { AppModule } from "../../src/app.module";
+import { RunMode } from "../../src/dynamic-module";
+import { ValidationPipe } from "../../src/validation.pipe";
+import { ChainIds } from "../../src/modules/web3/model/ChainId";
+import { DepositFixture } from "../../src/modules/deposit/adapter/db/deposit-fixture";
+
+let app: INestApplication;
+let depositGapCheckFixture: DepositGapCheckFixture;
+let depositFixture: DepositFixture;
+let depositGapService: DepositGapService;
+
+beforeAll(async () => {
+  const moduleFixture = await Test.createTestingModule({
+    imports: [AppModule.forRoot({ runModes: [RunMode.Normal, RunMode.Test, RunMode.Scraper] })],
+  }).compile();
+
+  app = moduleFixture.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe());
+  await app.init();
+
+  depositGapCheckFixture = app.get(DepositGapCheckFixture);
+  depositFixture = app.get(DepositFixture);
+  depositGapService = app.get(DepositGapService);
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe("DepositGapService::getLastDepositThatPassedGapCheck", () => {
+  beforeEach(async () => {
+    await depositGapCheckFixture.deleteAllDepositGapChecks();
+  });
+
+  afterEach(async () => {
+    await depositGapCheckFixture.deleteAllDepositGapChecks();
+  });
+
+  it("should return null if no gap checks in the db", async () => {
+    const result = await depositGapService.getLastDepositThatPassedGapCheck(ChainIds.optimism);
+    expect(result).toBeNull();
+  });
+
+  it("should return the last deposit id that passed gap check", async () => {
+    await depositGapCheckFixture.insertDepositGapCheck({ depositId: 0, originChainId: ChainIds.mainnet, passed: true });
+    await depositGapCheckFixture.insertDepositGapCheck({ depositId: 1, originChainId: ChainIds.mainnet, passed: true });
+    const result1 = await depositGapService.getLastDepositThatPassedGapCheck(ChainIds.mainnet);
+    expect(result1.depositId).toBe(1);
+  });
+});
+
+describe("DepositGapService::getDepositToStartGapCheck", () => {
+  beforeEach(async () => {
+    await depositGapCheckFixture.deleteAllDepositGapChecks();
+  });
+
+  afterEach(async () => {
+    await depositGapCheckFixture.deleteAllDepositGapChecks();
+  });
+
+  it("should start to check deposit from the spoke pool config", async () => {
+    const depositId = await depositGapService.getDepositToStartGapCheck(ChainIds.mainnet);
+    expect(depositId).toBe(0);
+  });
+
+  it("should start to check deposit from the last deposit gap check", async () => {
+    await depositGapCheckFixture.insertDepositGapCheck({ depositId: 0, originChainId: ChainIds.mainnet, passed: true });
+    await depositGapCheckFixture.insertDepositGapCheck({ depositId: 1, originChainId: ChainIds.mainnet, passed: true });
+    const depositId = await depositGapService.getDepositToStartGapCheck(ChainIds.mainnet);
+    expect(depositId).toBe(2);
+  });
+});
+
+describe("DepositGapService::checkDepositGaps", () => {
+  beforeEach(async () => {
+    await depositGapCheckFixture.deleteAllDepositGapChecks();
+    await depositFixture.deleteAllDeposits();
+  });
+
+  afterEach(async () => {
+    await depositGapCheckFixture.deleteAllDepositGapChecks();
+    await depositFixture.deleteAllDeposits();
+  });
+
+  it("should be no gaps if no deposits", async () => {
+    const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await depositGapService.checkDepositGaps(
+      ChainIds.mainnet,
+    );
+    expect(gapIntervals.length).toBe(0);
+    expect(lastDepositId).toBeUndefined();
+    expect(gapCheckPassDepositId).toBeUndefined();
+  });
+
+  it("should be no gaps if a single deposit", async () => {
+    await depositFixture.insertDeposit({ depositId: 0, sourceChainId: ChainIds.mainnet });
+    const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await depositGapService.checkDepositGaps(
+      ChainIds.mainnet,
+    );
+    expect(gapIntervals.length).toBe(0);
+    expect(lastDepositId).toBe(0);
+    expect(gapCheckPassDepositId).toBe(0);
+  });
+
+  it("should be no gaps if multiple deposit", async () => {
+    await depositFixture.insertDeposit({ depositId: 0, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 1, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 2, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 3, sourceChainId: ChainIds.mainnet });
+    const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await depositGapService.checkDepositGaps(
+      ChainIds.mainnet,
+    );
+    expect(gapIntervals.length).toBe(0);
+    expect(lastDepositId).toBe(3);
+    expect(gapCheckPassDepositId).toBe(3);
+  });
+
+  it("should detect gaps", async () => {
+    await depositGapCheckFixture.insertDepositGapCheck({ depositId: 0, originChainId: ChainIds.mainnet, passed: true });
+    await depositGapCheckFixture.insertDepositGapCheck({ depositId: 1, originChainId: ChainIds.mainnet, passed: true });
+    await depositGapCheckFixture.insertDepositGapCheck({ depositId: 2, originChainId: ChainIds.mainnet, passed: true });
+    await depositFixture.insertDeposit({ depositId: 0, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 1, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 2, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 3, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 5, sourceChainId: ChainIds.mainnet });
+    const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await depositGapService.checkDepositGaps(
+      ChainIds.mainnet,
+    );
+    expect(gapIntervals).toStrictEqual([{ fromDepositId: 4, toDepositId: 4 }]);
+    expect(lastDepositId).toBe(5);
+    expect(gapCheckPassDepositId).toBe(3);
+  });
+
+  it("should detect gaps", async () => {
+    await depositFixture.insertDeposit({ depositId: 0, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 1, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 2, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 3, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 5, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 10, sourceChainId: ChainIds.mainnet });
+    const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await depositGapService.checkDepositGaps(
+      ChainIds.mainnet,
+    );
+    expect(gapIntervals).toStrictEqual([
+      { fromDepositId: 4, toDepositId: 4 },
+      { fromDepositId: 6, toDepositId: 9 },
+    ]);
+    expect(lastDepositId).toBe(10);
+    expect(gapCheckPassDepositId).toBe(3);
+  });
+
+  it("should detect gaps", async () => {
+    await depositFixture.insertDeposit({ depositId: 1, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 2, sourceChainId: ChainIds.mainnet });
+    const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await depositGapService.checkDepositGaps(
+      ChainIds.mainnet,
+    );
+    expect(gapIntervals).toStrictEqual([{ fromDepositId: 0, toDepositId: 0 }]);
+    expect(lastDepositId).toBe(2);
+    expect(gapCheckPassDepositId).toBeUndefined();
+  });
+
+  it("should detect gaps", async () => {
+    await depositGapCheckFixture.insertDepositGapCheck({ depositId: 0, originChainId: ChainIds.mainnet, passed: true });
+    await depositFixture.insertDeposit({ depositId: 0, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 3, sourceChainId: ChainIds.mainnet });
+    await depositFixture.insertDeposit({ depositId: 5, sourceChainId: ChainIds.mainnet });
+    const { gapIntervals, lastDepositId, gapCheckPassDepositId } = await depositGapService.checkDepositGaps(
+      ChainIds.mainnet,
+    );
+    expect(gapIntervals).toStrictEqual([
+      { fromDepositId: 1, toDepositId: 2 },
+      { fromDepositId: 4, toDepositId: 4 },
+    ]);
+    expect(lastDepositId).toBe(5);
+    expect(gapCheckPassDepositId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This PR adds deposit gap detection in the Across scraper.

**How it works:**
1. There's a new [deposit_gap_check](https://github.com/across-protocol/scraper-api/pull/368/files#diff-8359bea7a41a52f7fd73f2d59269c452b53ea0b924d477138c705a895afbdad4) table which stores the last deposit id that passes the gap check, meaning that they don't have gaps preceding them. This is useful to detect missing deposit events that need to be re-scraped.
2. There's a new [DepositGapService](https://github.com/across-protocol/scraper-api/pull/368/files#diff-1ed0239b8ef38c1d46359b1f174359ec4e31f67a1e4544ca9497427b02e7b1e1) which contains useful the logic for managing deposits gaps. 
The most important function is `checkDepositGaps()` that returns and object containing the following properties: 
- gapIntervals - a list of block gaps intervals `{ fromDepositId, toDepositId }`  
- lastDepositId - the max deposit id in the DB
- gapCheckPassDepositId - the max `depositId` that passes the gap check
3. The automation of deposit gap detection is done using [DepositsGapDetectionCron](https://github.com/across-protocol/scraper-api/pull/368/files#diff-c6facc94899d47679fd67ad1f69d763f3aec8bfebc11b5d962a80dfde838eabe) cron that runs every 10 minutes.

⚠️ For now this cron only checks for gaps. After running for some time in production, the next step is to add automatic re-scraping of the blocks containing missing deposits.

4. Each time a gap is detected a message is posted in the `zbot-across-scraper-production` Slack channel

<img width="682" alt="Screenshot 2024-03-21 at 17 38 31" src="https://github.com/across-protocol/scraper-api/assets/89395931/1f44336d-639d-4bfc-bb5a-f574f97a09ac">

