### PR TITLE
fix: get filled date from receipt

### DIFF
--- a/src/modules/scraper/adapter/messaging/DepositFilledDateConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/DepositFilledDateConsumer.ts
@@ -68,7 +68,7 @@ export class DepositFilledDateConsumer {
   private async fillDateForFillTx(chainId: number, fillTx: DepositFillTx | DepositFillTx2 | DepositFillTxV3) {
     if (fillTx.date) return fillTx;
 
-    const tx = await this.providers.getCachedTransaction(chainId, fillTx.hash);
+    const tx = await this.providers.getCachedTransactionReceipt(chainId, fillTx.hash);
     const block = await this.providers.getCachedBlock(chainId, tx.blockNumber);
 
     return {


### PR DESCRIPTION
For each fill transaction stored in the DB, get the date from the receipt instead of the tx