### PR TITLE
fix: fix op reward bug

### DIFF
--- a/src/modules/rewards/services/op-rebate-service.ts
+++ b/src/modules/rewards/services/op-rebate-service.ts
@@ -262,8 +262,9 @@ export class OpRebateService {
       rewardToken.symbol.toLowerCase(),
     );
     const rewardsUsd = new BigNumber(bridgeFeeUsd).multipliedBy(OP_REBATE_RATE).toFixed();
+    const positiveRewardsUsd = BigNumber.max(new BigNumber(0), rewardsUsd);
     const rewardsAmount = ethers.utils.parseEther(
-      new BigNumber(rewardsUsd).dividedBy(historicRewardTokenPrice.usd).toFixed(18),
+      new BigNumber(positiveRewardsUsd).dividedBy(historicRewardTokenPrice.usd).toFixed(18),
     );
 
     return {


### PR DESCRIPTION
This PR fixes a bug that was causing negative OP rewards when the bridge fee is negative. This fix will not allow computed OP rewards to go below 0