### PR TITLE
fix: replace json rpc with static json rpc provider

### DIFF
--- a/src/modules/web3/services/EthProvidersService.ts
+++ b/src/modules/web3/services/EthProvidersService.ts
@@ -196,7 +196,10 @@ export class EthProvidersService {
 
     for (const chainId of supportedChainIds) {
       if (this.appConfig.values.web3.providers[chainId]) {
-        const provider = new ethers.providers.JsonRpcProvider(this.appConfig.values.web3.providers[chainId]);
+        const provider = new ethers.providers.StaticJsonRpcProvider(
+          this.appConfig.values.web3.providers[chainId],
+          Number(chainId),
+        );
         this.providers[chainId] = provider;
       }
     }


### PR DESCRIPTION
The usage of `JsonRpcProvider` triggers additional `eth_chainId ` calls with every RPC call we make in order to ensure that the provider url matches the network. This is not necessary because the scraper doesn't change the providers, so we are safe to use `StaticJsonRpcProvider` 