### PR TITLE
fix: serve arb rewards proofs

### DIFF
--- a/src/modules/airdrop/entry-points/http/dto.ts
+++ b/src/modules/airdrop/entry-points/http/dto.ts
@@ -60,7 +60,6 @@ export class EditWalletRewardsBody {
   welcomeTravellerRewards: string;
 }
 
-export const IncludeDiscordQueryValues = ["true", "false"] as const;
 export class GetMerkleDistributorProofQuery {
   @IsNumberString()
   windowIndex: number;
@@ -68,14 +67,9 @@ export class GetMerkleDistributorProofQuery {
   @IsEthereumAddress()
   address: string;
 
-  @IsEnum(IncludeDiscordQueryValues)
-  @IsOptional()
-  includeDiscord: typeof IncludeDiscordQueryValues[number];
-
   @IsEnum(RewardsType)
-  @IsOptional()
-  @ApiProperty({ example: "referrals", required: false, enum: RewardsType })
-  rewardsType?: RewardsType;
+  @ApiProperty({ example: RewardsType.ArbRewards, enum: RewardsType })
+  rewardsType: RewardsType;
 }
 
 export class GetMerkleDistributorProofsQuery {
@@ -90,8 +84,8 @@ export class GetMerkleDistributorProofsQuery {
 
   @IsEnum(RewardsType)
   @IsOptional()
-  @ApiProperty({ example: "referrals", required: false, enum: RewardsType })
-  rewardsType?: RewardsType;
+  @ApiProperty({ example: RewardsType.ArbRewards, enum: RewardsType })
+  rewardsType: RewardsType;
 }
 
 export class GetEtlMerkleDistributorRecipientsQuery {

--- a/src/modules/airdrop/services/airdrop-service.ts
+++ b/src/modules/airdrop/services/airdrop-service.ts
@@ -246,7 +246,9 @@ export class AirdropService {
     const { address, windowIndex, rewardsType } = query;;
     let contractAddress: string | undefined = undefined;
 
-    if (rewardsType === RewardsType.OpRewards) {
+    if (rewardsType === RewardsType.ReferralRewards) {
+      contractAddress = this.appConfig.values.web3.merkleDistributor.address;
+    } else if (rewardsType === RewardsType.OpRewards) {
       contractAddress = this.appConfig.values.web3.merkleDistributorContracts.opRewards.address;
     } else if (rewardsType === RewardsType.ArbRewards) {
       contractAddress = this.appConfig.values.web3.merkleDistributorContracts.arbRewards.address;
@@ -291,7 +293,9 @@ export class AirdropService {
 
     let contractAddress: string | undefined = undefined;
 
-    if (rewardsType === RewardsType.OpRewards) {
+    if (rewardsType === RewardsType.ReferralRewards) {
+      contractAddress = this.appConfig.values.web3.merkleDistributor.address;
+    } else if (rewardsType === RewardsType.OpRewards) {
       contractAddress = this.appConfig.values.web3.merkleDistributorContracts.opRewards.address;
     } else if (rewardsType === RewardsType.ArbRewards) {
       contractAddress = this.appConfig.values.web3.merkleDistributorContracts.arbRewards.address;

--- a/src/modules/rewards/model/RewardsWindowJob.entity.ts
+++ b/src/modules/rewards/model/RewardsWindowJob.entity.ts
@@ -14,6 +14,7 @@ export type ReferralRewardsWindowJobConfig = {
 export enum RewardsType {
   ReferralRewards = "referral-rewards",
   OpRewards = "op-rewards",
+  ArbRewards = "arb-rewards",
 }
 /**
  * @description This class represents a job for creating referral rewards windows

--- a/test/airdrop/merkle-distributor.e2e-spec.ts
+++ b/test/airdrop/merkle-distributor.e2e-spec.ts
@@ -38,7 +38,7 @@ afterAll(async () => {
 });
 
 describe("GET /airdrop/merkle-distributor-proof", () => {
-  const url = "/airdrop/merkle-distributor-proof";
+  const url = "/airdrop/merkle-distributor-proof?rewardsType=arb-rewards";
 
   afterEach(async () => {
     await merkleDistributorWindowFixture.deleteAllMerkleDistributorWindows();
@@ -54,7 +54,7 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
       windowIndex: 0,
       rewardToken: "0xrewardtoken",
       rewardsToDeposit: "10",
-      contractAddress: "0xF633b72A4C2Fb73b77A379bf72864A825aD35b6D",
+      contractAddress: "0x9f6Cb0A37F1ae91b8e65405f525A596bAFC5A9a6",
     });
     await merkleDistributorRecipientFixture.insertMerkleDistributorRecipient({
       accountIndex: 0,
@@ -79,53 +79,6 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
     expect(response.statusCode).toStrictEqual(200);
     expect(response.body.address).toStrictEqual(address);
     expect(response.body.windowIndex).toStrictEqual(0);
-    expect(response.body.discord).toStrictEqual(null);
-  });
-
-  it("should get the merkle proof and discord details", async () => {
-    const address = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D";
-    const user = await userFixture.insertUser({
-      discordAvatar: "https://discord.avatar",
-      discordId: "discordId",
-      discordName: "discordName",
-    });
-    await userWalletFixture.insertUserWallet({ userId: user.id, walletAddress: address });
-    const window = await merkleDistributorWindowFixture.insertMerkleDistributorWindow({
-      merkleRoot: "0xmerkleroot",
-      windowIndex: 0,
-      rewardToken: "0xrewardtoken",
-      rewardsToDeposit: "10",
-      contractAddress: "0xF633b72A4C2Fb73b77A379bf72864A825aD35b6D",
-    });
-    await merkleDistributorRecipientFixture.insertMerkleDistributorRecipient({
-      accountIndex: 0,
-      address,
-      amount: "10",
-      merkleDistributorWindowId: window.id,
-      proof: ["0xproof"],
-      payload: {
-        amountBreakdown: {
-          communityRewards: "2",
-          earlyUserRewards: "2",
-          liquidityProviderRewards: "2",
-          welcomeTravelerRewards: "4",
-          referralRewards: "0",
-        },
-      },
-    });
-    const response = await request(app.getHttpServer()).get(url).query({
-      address,
-      windowIndex: 0,
-      includeDiscord: true,
-    });
-    expect(response.statusCode).toStrictEqual(200);
-    expect(response.body.address).toStrictEqual(address);
-    expect(response.body.windowIndex).toStrictEqual(0);
-    expect(response.body.discord).toStrictEqual({
-      discordAvatar: "https://discord.avatar",
-      discordId: "discordId",
-      discordName: "discordName",
-    });
   });
 
   it("should return empty if window index is incorrect", async () => {
@@ -135,7 +88,7 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
       windowIndex: 0,
       rewardToken: "0xrewardtoken",
       rewardsToDeposit: "10",
-      contractAddress: "0xF633b72A4C2Fb73b77A379bf72864A825aD35b6D",
+      contractAddress: "0x9f6Cb0A37F1ae91b8e65405f525A596bAFC5A9a6",
     });
     await merkleDistributorRecipientFixture.insertMerkleDistributorRecipient({
       accountIndex: 0,
@@ -168,7 +121,7 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
       windowIndex: 0,
       rewardToken: "0xrewardtoken",
       rewardsToDeposit: "10",
-      contractAddress: "0xF633b72A4C2Fb73b77A379bf72864A825aD35b6D",
+      contractAddress: "0x9f6Cb0A37F1ae91b8e65405f525A596bAFC5A9a6",
     });
     await merkleDistributorRecipientFixture.insertMerkleDistributorRecipient({
       accountIndex: 0,
@@ -196,7 +149,7 @@ describe("GET /airdrop/merkle-distributor-proof", () => {
 });
 
 describe("GET /airdrop/merkle-distributor-proofs", () => {
-  const url = "/airdrop/merkle-distributor-proofs";
+  const url = "/airdrop/merkle-distributor-proofs?rewardsType=arb-rewards";
 
   const address = "0x00B591BC2b682a0B30dd72Bac9406BfA13e5d3cd";
 
@@ -207,14 +160,14 @@ describe("GET /airdrop/merkle-distributor-proofs", () => {
         windowIndex: 0,
         rewardToken: "0xrewardtoken",
         rewardsToDeposit: "10",
-        contractAddress: "0xF633b72A4C2Fb73b77A379bf72864A825aD35b6D",
+        contractAddress: "0x9f6Cb0A37F1ae91b8e65405f525A596bAFC5A9a6",
       },
       {
         merkleRoot: "0xmerkleroot",
         windowIndex: 1,
         rewardToken: "0xrewardtoken",
         rewardsToDeposit: "10",
-        contractAddress: "0xF633b72A4C2Fb73b77A379bf72864A825aD35b6D",
+        contractAddress: "0x9f6Cb0A37F1ae91b8e65405f525A596bAFC5A9a6",
       },
     ]);
     await merkleDistributorRecipientFixture.insertManyMerkleDistributorRecipients([


### PR DESCRIPTION
This PR adds the ability to serve arb rewards proofs and also removes some old functionality from the rewards