### PR TITLE
fix: fix fee breakdown

### DIFF
--- a/src/modules/scraper/adapter/messaging/FeeBreakdownConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/FeeBreakdownConsumer.ts
@@ -110,7 +110,11 @@ export class FeeBreakdownConsumer {
       deposit.destinationChainId,
       fillTx.hash,
     );
-    const relayGasFeePct = new BigNumber(relayGasFeeUsd).dividedBy(bridgeFeeUsd).multipliedBy(bridgeFeePct);
+    const relayGasFeePct = bridgeFeeUsd.eq(0)
+      ? new BigNumber(0)
+      : new BigNumber(relayGasFeeUsd)
+          .dividedBy(bridgeFeeUsd)
+          .multipliedBy(bridgeFeePct);
     const { pctAmount: relayGasFeeAmount } = calcPctValues(relayGasFeePct.toFixed(0));
 
     // Swap fee computation


### PR DESCRIPTION
If `bridgeFeeUsd` is 0 than `relayGasFeePct` should be 0, otherwise `.dividedBy(bridgeFeeUsd)` will fail (division by 0)