### PR TITLE
fix: redstone first deposit id

### DIFF
--- a/.github/workflows/lint-build-test.yaml
+++ b/.github/workflows/lint-build-test.yaml
@@ -50,7 +50,7 @@ jobs:
       - uses: ./.github/actions/setup
       - run: cp .env.sample .env.test
       - name: Start postgres and redis
-        run: docker-compose -f docker-compose.e2e.yml up -d postgres redis
+        run: docker compose -f docker-compose.e2e.yml up -d postgres redis
       - name: Run migrations
         run: yarn db:migration:run
       - name: Run e2e tests

--- a/src/modules/configuration/index.ts
+++ b/src/modules/configuration/index.ts
@@ -374,7 +374,7 @@ export const configValues = () => ({
           startBlockNumber: 5158526,
           abi: JSON.stringify(SpokePoolV3Abi),
           acrossVersion: AcrossContractsVersion.V3,
-          firstDepositId: 1000000,
+          firstDepositId: 1,
         },
       ],
     },


### PR DESCRIPTION
The first deposit id on Redstone is 1 actually. This shouldn't have had an impact on the production Scraper because indexing of Redstone is not enabled yet.