### PR TITLE
fix: missed fill event cron

### DIFF
--- a/src/modules/scraper/adapter/messaging/FindMissedFillEventConsumer.ts
+++ b/src/modules/scraper/adapter/messaging/FindMissedFillEventConsumer.ts
@@ -78,6 +78,7 @@ export class FindMissedFillEventConsumer {
           { id: jobId },
           { status: FindMissedFillEventJobStatus.Suspended },
         );
+        return;
       }
     }
 

--- a/src/modules/scraper/service/CheckMissedFillEventsCron.ts
+++ b/src/modules/scraper/service/CheckMissedFillEventsCron.ts
@@ -54,7 +54,6 @@ export class CheckMissedFillEventsCron {
       .where("d.status = :status", { status: "pending" })
       .andWhere("d.outputTokenAddress is not null")
       .andWhere("d.depositDate <= NOW() - INTERVAL '5 minutes'")
-      .andWhere("d.fillDeadline >= NOW()") // ignore expired deposits
       .andWhere("j.id is null")
       .orderBy("d.depositDate", "DESC")
       .limit(1000)

--- a/src/modules/scraper/service/CheckMissedFillEventsCron.ts
+++ b/src/modules/scraper/service/CheckMissedFillEventsCron.ts
@@ -54,7 +54,9 @@ export class CheckMissedFillEventsCron {
       .where("d.status = :status", { status: "pending" })
       .andWhere("d.outputTokenAddress is not null")
       .andWhere("d.depositDate <= NOW() - INTERVAL '5 minutes'")
+      .andWhere("d.fillDeadline >= NOW()") // ignore expired deposits
       .andWhere("j.id is null")
+      .orderBy("d.depositDate", "DESC")
       .limit(1000)
       .getMany();
     this.logger.verbose(`Found ${deposits.length} deposits to check`);


### PR DESCRIPTION
The cron we use to look for missed fill events checks up to 1000 deposits each time. Since there are more than 1000 pending deposits in the database, for the thousand we were processing each run, we were founding only a dozen of fills. 
To avoid that, this PR modifies the query we do to order deposits by deposit date to check first the most recent ones.

It also fix a bug that kept suspended 'FindMissedFillEvent" jobs looping. Now they will stop running once the status is changed to suspended.

I'm still looking why we are missing so much fill events when we process blocks, specially on Base. But in the meantime, this should help us find more missed fills.