### PR TITLE
fix: track earned op rewards

### DIFF
--- a/migrations/1736706626171-OpRewardsStats.ts
+++ b/migrations/1736706626171-OpRewardsStats.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class OpRewardsStats1736706626171 implements MigrationInterface {
+  name = "OpRewardsStats1736706626171";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "op_rewards_stats" (
+        "id" integer NOT NULL, 
+        "totalTokenAmount" numeric NOT NULL, 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "PK_489a963c1c293a7be951b09b793" PRIMARY KEY ("id"))
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "op_rewards_stats"`);
+  }
+}

--- a/src/modules/database/database.providers.ts
+++ b/src/modules/database/database.providers.ts
@@ -32,6 +32,7 @@ import { ArbReward } from "../rewards/model/arb-reward.entity";
 import { FindMissedFillEventJob } from "../scraper/model/FindMissedFillEventJob.entity";
 import { HubPoolProcessedBlock } from "../scraper/model/HubPoolProcessedBlock.entity";
 import { SetPoolRebalanceRouteEvent } from "../web3/model/SetPoolRebalanceRouteEvent.entity";
+import { OpRewardsStats } from "../rewards/model/op-rewards-stats.entity";
 
 // TODO: Add db entities here
 const entities = [
@@ -66,6 +67,7 @@ const entities = [
   FindMissedFillEventJob,
   HubPoolProcessedBlock,
   SetPoolRebalanceRouteEvent,
+  OpRewardsStats,
 ];
 
 @Injectable()

--- a/src/modules/rewards/model/op-rewards-stats.entity.ts
+++ b/src/modules/rewards/model/op-rewards-stats.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+export type RewardMetadata = {
+  rate: number;
+};
+
+@Entity()
+export class OpRewardsStats {
+  @PrimaryColumn()
+  id: number;
+
+  @Column({ type: "decimal" })
+  totalTokenAmount: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/rewards/module.ts
+++ b/src/modules/rewards/module.ts
@@ -22,6 +22,8 @@ import { RewardsWindowJobFixture } from "./adapter/db/rewards-window-job-fixture
 import { ArbRebateService } from "./services/arb-rebate-service";
 import { ArbReward } from "./model/arb-reward.entity";
 import { ArbRewardFixture } from "./adapter/db/arb-reward-fixture";
+import { OpRewardsStatsCron } from "./services/OpRewardsStatsCron";
+import { OpRewardsStats } from "./model/op-rewards-stats.entity";
 
 @Module({})
 export class RewardModule {
@@ -29,7 +31,14 @@ export class RewardModule {
     const module: DynamicModule = {
       module: RewardModule,
       controllers: [RewardController],
-      providers: [RewardService, OpRebateService, ReferralService, ReferralRewardsService, ArbRebateService],
+      providers: [
+        RewardService,
+        OpRebateService,
+        ReferralService,
+        ReferralRewardsService,
+        ArbRebateService,
+        OpRewardsStatsCron,
+      ],
       imports: [
         TypeOrmModule.forFeature([
           Deposit,
@@ -38,13 +47,19 @@ export class RewardModule {
           RewardsWindowJob,
           ReferralRewardsWindowJobResult,
           ArbReward,
+          OpRewardsStats,
         ]),
         AppConfigModule,
         Web3Module,
         ReferralModule.forRoot(moduleOptions),
         MarketPriceModule.forRoot(),
       ],
-      exports: [RewardService, OpRebateService, ReferralService, ArbRebateService],
+      exports: [
+        RewardService,
+        OpRebateService,
+        ReferralService,
+        ArbRebateService,
+      ],
     };
 
     if (moduleOptions.runModes.includes(RunMode.Test)) {

--- a/src/modules/rewards/services/OpRewardsStatsCron.ts
+++ b/src/modules/rewards/services/OpRewardsStatsCron.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { CronExpression } from "@nestjs/schedule";
+import { Repository } from "typeorm";
+import { InjectRepository } from "@nestjs/typeorm";
+
+import { EnhancedCron } from "../../../utils";
+import { OpReward } from "../model/op-reward.entity";
+import { OpRewardsStats } from "../model/op-rewards-stats.entity";
+
+@Injectable()
+export class OpRewardsStatsCron {
+  private logger = new Logger(OpRewardsStatsCron.name);
+  private semaphore = false;
+
+  constructor(
+    @InjectRepository(OpReward)
+    private opRewardRepository: Repository<OpReward>,
+    @InjectRepository(OpRewardsStats)
+    private opRewardsStatsRepository: Repository<OpRewardsStats>,
+  ) {}
+
+  @EnhancedCron(CronExpression.EVERY_30_SECONDS)
+  async startCron() {
+    try {
+      if (this.semaphore) return;
+      this.semaphore = true;
+
+      await this.computeOpRewardsStats();
+
+      this.semaphore = false;
+    } catch (error) {
+      this.semaphore = false;
+      this.logger.error(error);
+    }
+  }
+
+  private async computeOpRewardsStats() {
+    const totalAmount = await this.opRewardRepository.query(`
+      select sum(r.amount::decimal)
+      from op_reward r;
+    `);
+
+    if (totalAmount?.[0]?.sum) {
+      this.logger.log(`Total OP rewards: ${totalAmount?.[0]?.sum}`);
+      await this.opRewardsStatsRepository.upsert(
+        { id: 1, totalTokenAmount: totalAmount?.[0]?.sum },
+        { conflictPaths: { id: true } },
+      );
+    } else {
+      this.logger.error("No total amount found");
+    }
+  }
+}


### PR DESCRIPTION
This PR stores in DB how much OP have been earned so far. 
The next step is to check in the `OpRebateRewardConsumer` that the total OP earned is less than 750K. If so, OP rewards will not be allocated to deposits.

`SUM` is a relatively expensive query so it would have been ineficient to compute the sum for each deposit eligible for OP rewards. My approach was to use a precomputed value