### PR TITLE
feat: add endpoint to serve op rebates stats

### DIFF
--- a/src/modules/rewards/entrypoints/http/controller.ts
+++ b/src/modules/rewards/entrypoints/http/controller.ts
@@ -46,6 +46,12 @@ export class RewardController {
     return this.rewardService.getOpRebateRewardDeposits(query);
   }
 
+  @Get("rewards/op-rebates/stats")
+  @ApiTags("rewards")
+  getOpRebatesStats() {
+    return this.rewardService.getOpRebatesStats();
+  }
+
   @Get("rewards/referrals/summary")
   @ApiTags("rewards")
   getReferralsSummary(@Query() query: GetReferralRewardsSummaryQuery) {

--- a/src/modules/rewards/services/reward-service.ts
+++ b/src/modules/rewards/services/reward-service.ts
@@ -31,6 +31,7 @@ import { AppConfig } from "../../configuration/configuration.service";
 // Cache Keys
 const getArbRebatesSummaryCacheKey = (address: string) => `arbRebates:summary:${address}`;
 const getOpRebatesSummaryCacheKey = (address: string) => `opRebates:summary:${address}`;
+const getOpRebatesStatsCacheKey = () => `opRebates:stats`;
 const getEarnedRewardsCacheKey = (address: string) => `earnedRewards:${address}`;
 
 @Injectable()
@@ -119,6 +120,23 @@ export class RewardService {
       })),
       pagination,
     };
+  }
+
+  public async getOpRebatesStats() {
+    let data = await this.cacheManager.get(getOpRebatesStatsCacheKey());
+    if (data) return data;
+
+    data = await this.opRebateService.getOpRebatesStats();
+
+    if (this.appConfig.values.app.cacheDuration.rebatesData) {
+      await this.cacheManager.set(
+        getOpRebatesStatsCacheKey(),
+        data,
+        60,
+      );
+    }
+
+    return data;
   }
 
   public async getOpRebatesSummary(query: GetSummaryQuery) {

--- a/src/modules/scraper/module.ts
+++ b/src/modules/scraper/module.ts
@@ -61,6 +61,7 @@ import { Block } from "../web3/model/block.entity";
 import { ArbReward } from "../rewards/model/arb-reward.entity";
 import { HubPoolBlocksEventsConsumer } from "./adapter/messaging/HubPoolBlocksEventsConsumer";
 import { HubPoolProcessedBlock } from "./model/HubPoolProcessedBlock.entity";
+import { OpRewardsStats } from "../rewards/model/op-rewards-stats.entity";
 
 @Module({})
 export class ScraperModule {
@@ -129,6 +130,7 @@ export class ScraperModule {
           FindMissedFillEventJob,
           Block,
           HubPoolProcessedBlock,
+          OpRewardsStats,
         ]),
         MarketPriceModule.forRoot(),
         HttpModule,


### PR DESCRIPTION
`GET /rewards/op-rebates/stats`

```
{
    "totalTokenAmount": "<WEI_OP_AMOUNT>",
}
```